### PR TITLE
Planning docs v2, G1 headless credential engine, crash fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,23 @@ working on the code.
 
 Current version: 0.4.0 (kept in sync across `docs/README.md`,
 `pyproject.toml`, `freecad_gitpdm/__init__.py`, and `Init.py` — bump all four
-together when releasing).
+together when releasing). `v0.4.0` is tagged from pre-credential-engine
+`main`; the next release is v0.5.0 (see roadmap below).
+
+## Roadmap / current status
+
+Development follows `GITPDM_DEV_PLAN.md` (phases G1–G8, one phase = one PR)
+with `GITPDM_REQUIREMENTS.md` as the requirements companion — both at the
+repo root on the `dev` branch. Read the phase brief before implementing,
+and update the plan's **Status ledger** in the same PR as the work.
+Feature work happens on `dev`; CI runs on push/PR to both `main` and `dev`.
+
+Status: **G1 (headless credential engine) is implemented** on `dev`.
+**Next up is G2**: tag-triggered release archive + container smoke job —
+the CI workflow itself already exists, do not rebuild it. G3 (storage
+modes) is parallel-safe and can run any time. The overriding constraint
+for every phase: desktop behavior must be a no-op or an improvement
+("the desktop user is sacred").
 
 ## Entry points / how FreeCAD loads this
 
@@ -31,7 +47,15 @@ when running tests or scripts outside the app.
 
 - `auth/` — GitHub OAuth device flow (`oauth_device_flow.py`), token storage
   abstracted per-OS (`token_store_wincred.py` / `_macos.py` / `_linux.py` via
-  `token_store_factory.py`), scope validation, token refresh.
+  `token_store_factory.py`), scope validation, token refresh. Headless
+  credential resolution (`credential_chain.py`): `GITPDM_TOKEN_FILE` >
+  `GITPDM_TOKEN` > keyring, with an opt-in file store
+  (`token_store_file.py`, only reachable when `GITPDM_ALLOW_FILE_TOKENS=1` —
+  a security invariant asserted by tests). `python -m freecad_gitpdm.auth.check`
+  is the keyring-less container smoke test; it must keep working without
+  FreeCAD installed. When env credential backends are active, `git/client.py`
+  bridges the token into network git commands via an inline credential
+  helper; on desktop (no env vars) that bridge must stay a no-op.
 - `git/client.py` — subprocess wrapper around the `git` CLI; all Git
   operations (commit/push/pull/fetch/branch) go through here.
 - `github/` — GitHub REST API client, rate limiting, repo creation, identity,

--- a/GITPDM_DEV_PLAN.md
+++ b/GITPDM_DEV_PLAN.md
@@ -1,0 +1,216 @@
+# GitPDM — Phased Development Plan (Implementation Briefs)
+
+**Status:** Draft v2 — reviewed against the actual codebase at v0.4.0 (commit `f94343c`, 2026-07-16)
+**Audience:** a coding agent (Claude Code) implementing one phase at a time in `nerd-sniped/GitPDM`. Each phase is written as a self-contained brief; both this file and `GITPDM_REQUIREMENTS.md` are committed to the repo, so read them from there.
+**Companion:** requirement IDs (R1.1, R2.1a, …) refer to `GITPDM_REQUIREMENTS.md`.
+
+## Revision notes (v2, codebase review)
+
+Draft v1 was written from the README; v2 corrects it against the code. Substantive changes:
+
+- **G1 reframed from "replace" to "extend".** Token expiry/refresh (R2.1a) already exists (`auth/token_refresh.py`, `TokenResponse` with `refresh_token`/`expires_in`/`obtained_at_utc`), as does a `TokenStore` ABC with per-OS backends behind a factory. G1's real gap is the headless resolution rungs, the `provider` field, chain orchestration, and the CLI check.
+- **G2 de-duplicated.** CI (ruff + pytest on 3 OSes × Python 3.10–3.12 + architecture guard) already exists in `.github/workflows/ci.yml`. Only the tag-triggered release build and container smoke job are new.
+- **Versioning decided:** `v0.4.0` was tagged from pre-G1 `main` on 2026-07-16 (fixes the dead "download latest release" link immediately). The release carrying G1+G2 is **v0.5.0**.
+- **G3 now points at shipped code to fix:** `core/settings.py` already silently flips the global compression preference on repo open (the exact R1.2 harm) — G3 is partly a regression fix, not greenfield.
+- **G6 gained a hard constraint:** recovery-branch commits must use git plumbing (no checkout, no HEAD movement) because documents are open during checkpoints.
+- **R3.2 clarified:** no FreeCAD-in-CI; the support matrix is a documented policy verified manually per release (CI mocks FreeCAD by design).
+- Minor: benchmark script goes in `tools/` (repo convention), not `scripts/`; `.freecad-pdm/` config-file pattern already exists (`export/preset.py`) for G3 to mirror.
+
+---
+
+## How to use this document (instructions to the implementing agent)
+
+1. **Explore before editing.** Module names below (`freecad_gitpdm/`, `github/`, `git/`, `ui/`, `core/`, `export/`) come from the README's architecture section and may not match reality exactly. Map the actual layout first; adapt paths, preserve intent.
+2. **The desktop user is sacred.** Every phase must be a no-op or an improvement for someone running GitPDM in desktop FreeCAD with a keyring. If a change alters desktop behaviour, stop and flag it.
+3. **Tests must run without FreeCAD.** FreeCAD's Python API isn't pip-installable. Structure new code so business logic imports cleanly under plain pytest, with `FreeCAD`/`FreeCADGui`/`PySide` mocked or injected at the edges. UI and document-event code gets thin adapters; logic lives below them.
+4. **No new hard dependencies** beyond stdlib + what GitPDM already vendors. Git operations shell out (existing pattern); HTTP uses whatever the codebase already uses.
+5. **One phase = one PR.** Don't reach forward into later phases.
+
+---
+
+## Phase G1 — Credential engine *(BLOCKER for everything external)*
+
+**Implements:** R2.1, R2.1a. **Depends on:** nothing.
+
+**Context (corrected in v2):** GitPDM currently assumes an OS keyring — that assumption does fail in containers. But it does **not** model tokens as immortal strings: `auth/oauth_device_flow.py` defines `TokenResponse` with `refresh_token`, `expires_in`, `refresh_token_expires_in`, and `obtained_at_utc`; `auth/token_refresh.py` implements expiry detection (5-minute buffer), transparent refresh, and graceful degradation to re-auth (`ensure_fresh_token`). Persistence goes through a `TokenStore` ABC (`auth/token_store.py`) with per-OS backends chosen by `auth/token_store_factory.py`. **Extend these pieces; do not rewrite them.** What's missing: headless resolution rungs, a `provider` field, chain orchestration, and the CLI check.
+
+**Build:**
+1. Add `provider: str = "github"` to `TokenResponse` (or a thin `Credential` wrapper if extending the dataclass breaks deserialization of already-stored tokens — check how the per-OS stores serialize before choosing). Do **not** add a separate `expires_at`; that semantics already exists as `obtained_at_utc + expires_in`.
+2. A resolution chain module (e.g. `auth/credential_chain.py`), tried in order, each rung either *yielding*, *missing* (silent fall-through), or *erroring* (logged warning + fall-through, never a crash):
+   `GITPDM_TOKEN_FILE` → `GITPDM_TOKEN` → keyring (existing `create_token_store()`) → device flow (if provider supports) → PAT prompt.
+   The chain resolves the non-interactive rungs; the interactive rungs (device flow, PAT prompt) stay in the UI layer, which acts on the chain's outcome.
+3. File persistence backend: a new `TokenStore` implementation (`auth/token_store_file.py`) writing `~/.config/GitPDM/credentials.json`, `chmod 0600`, engaged **only** when `GITPDM_ALLOW_FILE_TOKENS=1`. Wire it through the factory following the existing per-OS pattern. Without the flag it must be unreachable — assert this in a test; it is the desktop-security invariant.
+4. Transparent refresh: **already implemented** (`token_refresh.ensure_fresh_token`). G1's job here is only to (a) verify it is actually invoked before every network git/API operation and close any gaps, and (b) parameterize the hardcoded GitHub token URL per provider. Env-sourced tokens are PATs with no refresh token; `is_token_expired` already treats missing expiry info as long-lived — no work needed there.
+5. A CLI-invokable check (`python -m freecad_gitpdm.auth.check`) that resolves the chain and prints the authenticated login. Must import and run with no FreeCAD installed (the `core/log.py` FreeCAD dependency must not leak in). This is the container smoke test.
+
+**Acceptance:**
+- Unit tests: every rung yields/misses/errors correctly; precedence order enforced; file backend unreachable without the env flag; refresh path exercised with a fake expiring token.
+- `docker run -e GITPDM_TOKEN=<pat> …auth.check` prints the login on a machine with no keyring daemon.
+- Existing keyring flow on desktop is behaviourally unchanged.
+
+**Do not:** log token values anywhere (add a test that greps captured logs); store tokens in FreeCAD parameters; add a keyring polyfill for containers.
+
+---
+
+## Phase G2 — Release + CI *(unblocks the sister repo's image build)*
+
+**Implements:** R3.1, R3.2. **Depends on:** G1 merged.
+
+**Context (corrected in v2):** CI already exists — `.github/workflows/ci.yml` runs ruff lint + format check, pytest across Python 3.10/3.11/3.12 on Linux/Windows/macOS (FreeCAD mocked via `tests/conftest.py`), and `tools/architecture_guard.py`, on push/PR to `main` and `dev`. **Do not rebuild it.** This phase only adds release automation.
+
+**Build:**
+1. Tag-triggered release job (extend `ci.yml` or add `release.yml`): on tag `v*` — build a release archive with the layout the tutorial describes (`Init.py`, `InitGui.py`, `freecad_gitpdm/`) and attach it to a GitHub Release. Existing lint/test/guard jobs stay untouched.
+2. A container smoke job: install the archive into a clean `Mod/`-shaped directory, `python -c "import freecad_gitpdm"` succeeds with FreeCAD mocked.
+3. Update the README support matrix: tested-against FreeCAD versions incl. 1.1.x, and the policy "current stable + one prior", verified manually before each release. No FreeCAD-in-CI (see R3.2 as revised — CI mocks FreeCAD by design).
+4. Bump the version to **0.5.0** across all four synced fields (`docs/README.md`, `pyproject.toml`, `freecad_gitpdm/__init__.py`, `Init.py` — per CLAUDE.md) and tag `v0.5.0`. (`v0.4.0` was already tagged from pre-G1 `main` on 2026-07-16; v0.5.0 is the release that carries the credential engine.)
+
+**Acceptance:** the release page has a downloadable archive; Tutorial 1's "download the latest release" instruction is now true; CI green including the pre-existing architecture guard.
+
+---
+
+## Phase G3 — Storage modes *(independent; ship any time before public docs)*
+
+**Implements:** R1.1, R1.2, R1.3, R1.4. **Depends on:** nothing (parallel-safe with G1/G2).
+
+**Context (sharpened in v2):** compression=0 and Git LFS are mutually defeating (see R1.1 rationale). This is not hypothetical: v0.4.0 ships `core/settings.py:ensure_git_friendly_fcstd_compression()`, called from `ui/repo_validator.py` on repo validation, which **silently sets the global FreeCAD `CompressionLevel` to 0 and does not record the prior value** — the exact harm R1.2 describes — while `docs/README.md` simultaneously recommends LFS. G3 replaces that function's behavior; it is partly a regression fix.
+
+**Build:**
+1. A single repo-scoped setting `storage_mode: "delta" | "lfs"` in `.freecad-pdm/config.json`. A `.freecad-pdm/` config-file mechanism already exists for export presets (`export/preset.py` reading `preset.json`) — mirror that pattern; it's also needed by G4. Default for new repos: `delta`.
+2. Mode application, atomically coupled:
+   - `delta` → FreeCAD compression 0, no LFS filter, write `*.FCStd binary` to `.gitattributes`.
+   - `lfs` → FreeCAD compression back to user's prior/default, LFS tracking for `*.FCStd`.
+3. Compression scoping (R1.2): apply the global `CompressionLevel` parameter only while a GitPDM repo is the active document context; restore the prior value on switch-away/close. If FreeCAD's API makes true scoping infeasible, fall back to: explicit consent dialog on first use + a visible log line on every change. Investigate `App.ParamGet("User parameter:BaseApp/Preferences/Document")` and document-activation signals; report which path was taken.
+4. UI: mode selector in settings; switching to `lfs` shows the warning that compression will be restored and why; the two forbidden states (compression 0 + LFS; `-delta` or LFS filter on `*.FCStd` in delta mode) are unreachable by construction.
+5. Benchmark script in `tools/` (repo convention — `scripts/` doesn't exist): save the same document 10× with a small change per save, in each mode, print `git count-objects -vH` growth. (Run headless via FreeCAD's CLI if available; otherwise document manual invocation.)
+
+**Acceptance:**
+- Unit test asserts forbidden-state unreachability.
+- Scoping test: open GitPDM repo → open unrelated doc → global compression equals the user's prior value.
+- `.gitattributes` written on repo creation contains exactly the delta-mode stanza; never contains `-delta`.
+- Benchmark script runs and reports.
+
+**Do not:** silently flip the global preference; promise text-like delta ratios in any doc string (R1.4 — BREP deltas are real but uneven).
+
+---
+
+## Phase G4 — Provider abstraction *(architecturally urgent: stops GitHub leakage)*
+
+**Implements:** R5.1, R5.2, R5.3, R4.3. **Depends on:** G1 (uses `Credential.provider`).
+
+**Context (expanded in v2):** the transport layer (`git/` subprocess wrapper) is already host-agnostic. The `github/` package is not — today it holds `api_client.py`, `cache.py`, `create_repo.py`, `errors.py`, `identity.py`, `rate_limiter.py`, `repos.py` — and every feature built before this refactor deepens the coupling. Note that `auth/` is *also* GitHub-coupled (device-flow endpoints and client ID in `auth/config.py`, hardcoded token URL in `token_refresh.py`): provider classes should own their auth endpoints so the G1 chain and refresh path can consult them. The generic provider is the **base case**, not a fallback.
+
+**Build:**
+1. Restructure `github/` → `providers/`:
+   - `base.py` — `GenericProvider`: plain git + PAT/SSH. **Zero host API calls.** Repo creation = instruct user to create in browser + paste URL. This class alone must make GitPDM fully functional.
+   - `github.py` — extends base: device flow, repo-creation API, (existing PR features if present).
+   - Capability flags on the class: `supports_device_flow`, `supports_repo_creation`, `supports_lfs_locking`, `supports_pull_requests`. UI reads flags and hides unavailable actions — it never offers an action that will fail.
+2. Provider selection persisted per-repo in `.freecad-pdm/config.json` (from G3): `{provider: "github" | "generic", remote_host: …}`. Two repos with different providers open in one session must not fight over global state.
+3. `gitlab.py` **stub only**: class exists, capability flags set (device flow true, per R5.2 GitLab ≥17.9), methods raise `NotImplementedError` with a tracking-issue reference. The stub's purpose is to prove the abstraction has a second consumer shape — full implementation is deferred.
+4. Rename sweep (R4.3): README title to git-based, repo topics, any UI strings saying "GitHub" where the provider is variable.
+
+**Acceptance:**
+- **The forcing test:** a scripted flow using `GenericProvider` against a bare git remote (a local `git init --bare` is fine) completes: configure → clone → save → commit → push, with zero HTTP calls (assert via a network-mock or by pointing at a nonexistent API host).
+- Existing GitHub flows behave identically to pre-refactor (regression suite or manual checklist).
+- UI shows no repo-creation button when the active provider lacks the capability.
+
+**Do not:** implement GitLab beyond the stub; build an SSH-key management UI (out of scope — generic provider assumes the user's git already authenticates, e.g. PAT in remote URL or ambient SSH agent); leak provider conditionals into `core/`/`export/` (all branching lives in `providers/`).
+
+---
+
+## Phase G5 — Container ergonomics
+
+**Implements:** R2.2 (dialog hardening), R2.3 (session guard), R2.4 (shallow clone + panel bootstrap). **Depends on:** G1, G4.
+
+**Build:**
+1. **Device-flow dialog hardening (R2.2):** URL and user code rendered as selectable text; "open browser" is a convenience button whose `xdg-open` failure is caught and non-fatal; dialog legible at 1080p streamed (no tiny fixed fonts).
+2. **Session guard (R2.3):** advisory lockfile `.git/gitpdm.lock` `{pid, timestamp, hostname}` on repo activation; stale-lock detection (dead PID or age > threshold → auto-clear); second live instance gets a warning dialog with override option, not a hard block.
+3. **Shallow-clone tolerance (R2.4):** audit every history-touching feature (log views, diffs, blame-ish features, export) against a `--depth 20` clone; each degrades to a "history truncated — deepen?" affordance (running `git fetch --deepen`) rather than erroring.
+4. **Panel-driven first run (R2.4):** from a fresh FreeCAD with GitPDM installed and a resolved credential, the panel offers *Clone existing* (URL field) or *Create new* (provider API if capability present; else instructions + paste URL). No terminal required end-to-end.
+
+**Acceptance:**
+- Scripted: `git clone --depth 20` a real repo → open in GitPDM → log view shows truncation affordance → deepen works → commit/push work.
+- Two-instance test: second process opening the same repo sees the warning; killing the first and retrying auto-clears.
+- Manual: complete first-run flow via panel only, in a container over a video stream.
+
+---
+
+## Phase G6 — Continuous checkpointing *(default-on; ships with the deployment MVP)*
+
+**Implements:** R2.5 (read it in full — it specifies triggers, guards, and the push-policy split). **Depends on:** G5.
+
+**Context:** this delivers the Onshape-style "walk away anytime, lose ≤ ~1 minute" guarantee via debounced checkpoints, not per-action persistence (prohibitive on FreeCAD's blocking whole-file save — see R2.5 rationale).
+
+**Build:**
+1. Checkpoint engine: idle-debounced (~30–60 s idle + dirty), max-interval backstop (2–5 min), external-signal hook (exposed so the container's SIGTERM handler can invoke save+checkpoint+push synchronously before exit).
+2. Transaction guard: query FreeCAD's active command/transaction state; skip and reschedule if busy. Never save mid-edit.
+3. Commit to `gitpdm/recovery` **without ever moving HEAD or touching the working tree** — documents are open during checkpoints, and the branch-switching corruption constraint applies (see CLAUDE.md / README). Use plumbing, not porcelain: build a tree via a temporary index (`GIT_INDEX_FILE` + `git add -A` + `git write-tree`), `git commit-tree` with the recovery branch tip as parent, then `git update-ref refs/heads/gitpdm/recovery <new-sha>`. Git operations async via subprocess — the Qt main thread is only ever touched by the save itself.
+4. Push policy: recovery-branch auto-push ON when headless credential backends (G1 env vars) are active, OFF on desktop by default; both overridable in settings.
+5. Restore-on-start prompt when recovery branch is ahead; prune/reset offer on next real commit.
+6. Settings coupling: in `lfs` mode, lengthen default checkpoint interval and say why (each checkpoint is a full stored LFS object; delta mode makes frequent checkpoints cheap).
+
+**Acceptance:**
+- Integration: dirty document → idle → checkpoint fires → `kill -9` the process → restart → restore offered → file round-trips intact.
+- SIGTERM path: external hook invoked → work present on recovery branch after process exit (this is the deployment's Phase 1.4 test from the sister repo's side).
+- Transaction guard: checkpoint scheduled during an active sketch edit does not fire until the edit closes.
+- Desktop default: no network push occurs without headless backends active (assert no push in test harness).
+- Mainline history never contains recovery commits.
+- A checkpoint leaves HEAD, the real index, and the working tree byte-identical to before (assert in test — this is the corruption-safety invariant).
+
+**Do not:** attempt per-action persistence or unsaved in-memory sync (explicit non-goal); auto-restore without prompting; block the UI on any git operation; check out, switch branches, or run any porcelain command that rewrites the working tree while documents are open.
+
+---
+
+## Phase G7 — Docs sweep *(gates public launch, not code)*
+
+**Implements:** R4.1, R4.2, R3.3. **Depends on:** G3 (modes must exist as described).
+
+1. Replace the "Git LFS (Why It's Recommended for CAD)" section with the storage-modes explainer drafted in R4.1.
+2. Reference section: state the delta/LFS opposition plainly (R4.2); document the credential chain and every `GITPDM_*` env var (from G1); shallow-clone behaviour (from G5).
+3. Include benchmark numbers from G3's script (real numbers, not projections).
+4. Submit to the FreeCAD addon index (R3.3).
+
+**Acceptance:** a new user following only the README makes the correct storage-mode choice for their situation; no doc contradicts shipped behaviour.
+
+---
+
+## Phase G8 — HistoryWorkbench integration *(spike may run any time; adapter after G4)*
+
+**Implements:** R5.5a–c (read §5b of the requirements in full — it contains the license boundary and the coexistence risk analysis). **Depends on:** spike: nothing; adapter: G4 (capability-flag pattern).
+
+**Context:** HistoryWorkbench (`eblanshey/HistoryWorkbench`, LGPL-2.1) provides visual 3D diff and review UX. GitPDM consumes it via runtime interop — **never fork it, never vendor its code** (LGPL boundary).
+
+**Build:**
+1. **Spike first (R5.5a):** install both addons on one project. Determine whether HW can operate against a GitPDM-managed repo, and where its internal git state lives. Write the finding to `docs/history-wb-interop.md` before any adapter code. If the answer is "needs upstream changes," stop and report — that's a collaboration conversation (R5.5d), not code.
+2. Adapter `integrations/history_wb.py` — the only module that may import or reference HW. Import probe + minimum-version check at runtime, never at module load. Expose `supports_visual_diff` through the G4 capability system.
+3. Diff invocation: materialize two revisions of an `.FCStd` to temp files via `git show <rev>:<path>`, call HW's compare entry point, clean up temp files after.
+4. UI: "Visual diff" action on any two versions in the history view — rendered only when the capability is true.
+5. CI pair test (R5.5c): commit a part twice with a dimension change, invoke the adapter, assert the comparison opens without error. Wire to run on any bump of either pinned version.
+
+**Acceptance:**
+- GitPDM with HW uninstalled: zero behavior change, no import errors, no visual-diff UI shown.
+- GitPDM with incompatible HW version: action hidden, one log line, no crash.
+- With compatible HW: two-commit dimension change produces an opened comparison.
+- `grep -r "history_wb" --include="*.py"` outside `integrations/` returns nothing (the choke-point invariant, as a test).
+
+**Do not:** copy any HW code into GitPDM (LGPL); import HW at module load; make any GitPDM feature *require* HW; write to HW's internal storage.
+
+---
+
+## Deferred (tracked, not scheduled)
+
+- **R2.6** touch-viable panel — after the deployment project's touch pass produces findings.
+- **D1** LFS locking — ships with a real `lfs`-mode team user, not before.
+- **D2** assembly link integrity — research spike first; likely GitPDM's long-term differentiator.
+- **GitLab full implementation** — exercises R2.1a's refresh path for real; schedule when a GitLab user exists.
+
+## Sequencing summary
+
+```
+G1 ──► G2 ──────────────► (sister repo can build)
+ │
+ ├──► G4 ──► G5 ──► G6
+ │      └──► G8 (adapter; spike runs any time)
+G3 (parallel, any time) ──► G7 (docs, pre-launch)
+```
+
+Critical path for the deployment project: **G1 → G2**. Everything else improves the product; those two unblock it.

--- a/GITPDM_DEV_PLAN.md
+++ b/GITPDM_DEV_PLAN.md
@@ -37,7 +37,7 @@ Also landed on `dev` (2026-07-17), outside any phase:
 Open items not yet closable:
 
 - **G1 container acceptance** (R2.1 acceptance criterion): `docker run -e GITPDM_TOKEN=<pat> … python -m freecad_gitpdm.auth.check` in a keyring-less image. Verified locally on Windows (chain, CLI, precedence, gating invariant, 162-test suite) but not yet in an actual container — G2's container smoke job should absorb this as a permanent CI check.
-- **v0.4.0 Release page**: the tag exists but the GitHub Release must be created via the web UI (no `gh` CLI on the dev machine). G2 automates this for v0.5.0.
+- ~~**v0.4.0 Release page**~~ ✅ Published 2026-07-17 (<https://github.com/nerd-sniped/GitPDM/releases/tag/v0.4.0>, source archive; Tutorial 1's download link now resolves). G2 still automates purpose-built archives for v0.5.0.
 
 ---
 

--- a/GITPDM_DEV_PLAN.md
+++ b/GITPDM_DEV_PLAN.md
@@ -16,6 +16,29 @@ Draft v1 was written from the README; v2 corrects it against the code. Substanti
 - **R3.2 clarified:** no FreeCAD-in-CI; the support matrix is a documented policy verified manually per release (CI mocks FreeCAD by design).
 - Minor: benchmark script goes in `tools/` (repo convention), not `scripts/`; `.freecad-pdm/` config-file pattern already exists (`export/preset.py`) for G3 to mirror.
 
+## Status ledger
+
+Keep this table current — update it in the same PR as the work it describes.
+
+| Phase | Status | Where / when |
+|---|---|---|
+| G1 credential engine | ✅ Implemented | `dev` @ `ceaa4f5`, 2026-07-17 |
+| G2 release + CI | ⏳ **Next up** | — |
+| G3 storage modes | Not started (parallel-safe) | — |
+| G4 provider abstraction | Not started (needs G1 ✅) | — |
+| G5–G8 | Not started | — |
+
+Also landed on `dev` (2026-07-17), outside any phase:
+
+- Fixed a `TypeError` in `list_local_branches`, `list_remote_branches`, and `pull_ff_only` (broken `timeout=N ** _get_subprocess_kwargs()` splat — these methods crashed on every call).
+- Fixed dead token-refresh wiring in `github/identity.py` (imported a nonexistent `get_token_store`; the ImportError was silently swallowed, so pre-request refresh never ran).
+- `v0.4.0` tagged from pre-G1 `main`.
+
+Open items not yet closable:
+
+- **G1 container acceptance** (R2.1 acceptance criterion): `docker run -e GITPDM_TOKEN=<pat> … python -m freecad_gitpdm.auth.check` in a keyring-less image. Verified locally on Windows (chain, CLI, precedence, gating invariant, 162-test suite) but not yet in an actual container — G2's container smoke job should absorb this as a permanent CI check.
+- **v0.4.0 Release page**: the tag exists but the GitHub Release must be created via the web UI (no `gh` CLI on the dev machine). G2 automates this for v0.5.0.
+
 ---
 
 ## How to use this document (instructions to the implementing agent)
@@ -28,9 +51,20 @@ Draft v1 was written from the README; v2 corrects it against the code. Substanti
 
 ---
 
-## Phase G1 — Credential engine *(BLOCKER for everything external)*
+## Phase G1 — Credential engine *(BLOCKER for everything external)* ✅ IMPLEMENTED
 
 **Implements:** R2.1, R2.1a. **Depends on:** nothing.
+
+**As built** (`dev` @ `ceaa4f5`, 2026-07-17 — kept for reference; the brief below is the original spec):
+
+- `auth/credential_chain.py` — `resolve_credential()` / `resolve_env_credential()` / `headless_backends_active()`; interactive rungs (device flow, PAT prompt) stay in the UI layer as planned.
+- `auth/token_store_file.py` — `FileTokenStore`, constructible only under `GITPDM_ALLOW_FILE_TOKENS=1`; factory falls back to it only when the flag is set AND the OS store is unavailable.
+- `TokenResponse.provider` (default `"github"`) rather than a separate `Credential` wrapper — stores serialize field-by-field with `.get()` defaults, so pre-existing stored tokens load unchanged.
+- `auth/check.py` — `python -m freecad_gitpdm.auth.check`, runs without FreeCAD.
+- `git/client.py:_headless_credential_args()` — bridges env tokens into `clone`/`fetch`/`pull`/`push` via an inline credential helper referencing env var names only (no token on any command line); returns `[]` on desktop so existing helpers are untouched. This item wasn't in the original brief but is required by R2.1's "authenticates and **pushes** in a container".
+- `core/services.py:github_api_client()` — env credentials take precedence; desktop path unchanged.
+- Refresh was already implemented but dead (see Status ledger); the wiring bug is fixed. Per-provider token URL parameterization deferred to G4 as planned.
+- Outstanding: the docker acceptance run (see Status ledger).
 
 **Context (corrected in v2):** GitPDM currently assumes an OS keyring — that assumption does fail in containers. But it does **not** model tokens as immortal strings: `auth/oauth_device_flow.py` defines `TokenResponse` with `refresh_token`, `expires_in`, `refresh_token_expires_in`, and `obtained_at_utc`; `auth/token_refresh.py` implements expiry detection (5-minute buffer), transparent refresh, and graceful degradation to re-auth (`ensure_fresh_token`). Persistence goes through a `TokenStore` ABC (`auth/token_store.py`) with per-OS backends chosen by `auth/token_store_factory.py`. **Extend these pieces; do not rewrite them.** What's missing: headless resolution rungs, a `provider` field, chain orchestration, and the CLI check.
 
@@ -52,9 +86,9 @@ Draft v1 was written from the README; v2 corrects it against the code. Substanti
 
 ---
 
-## Phase G2 — Release + CI *(unblocks the sister repo's image build)*
+## Phase G2 — Release + CI *(unblocks the sister repo's image build)* ⏳ NEXT UP
 
-**Implements:** R3.1, R3.2. **Depends on:** G1 merged.
+**Implements:** R3.1, R3.2. **Depends on:** G1 merged. ✅ (G1 is on `dev`; merge or branch from it.)
 
 **Context (corrected in v2):** CI already exists — `.github/workflows/ci.yml` runs ruff lint + format check, pytest across Python 3.10/3.11/3.12 on Linux/Windows/macOS (FreeCAD mocked via `tests/conftest.py`), and `tools/architecture_guard.py`, on push/PR to `main` and `dev`. **Do not rebuild it.** This phase only adds release automation.
 

--- a/GITPDM_REQUIREMENTS.md
+++ b/GITPDM_REQUIREMENTS.md
@@ -1,0 +1,330 @@
+# GitPDM — Requirements for Headless / Remote Operation
+
+**Status:** Draft v2 — triaged and corrected against the codebase at v0.4.0 (commit `f94343c`, 2026-07-16)
+**Target:** GitPDM v0.5.0 (v0.4.0 was tagged from pre-existing `main` on 2026-07-16; the work below lands in v0.5.0)
+**Context:** GitPDM is being adopted as the data layer for a browser-accessible, containerised FreeCAD deployment (single-user). This document captures what GitPDM must do to support that, plus storage-policy corrections that apply to *all* users, not just the remote case.
+
+**Baseline reviewed:** README @ v0.3.0; v2 revisions verified against source at v0.4.0. Notable v2 corrections: R2.1a (expiry/refresh already implemented — see revised rationale), R1.2 (the global-preference harm is *shipped behavior*, not hypothetical), R3.1 (v0.4.0 tag exists), R3.2 (no FreeCAD-in-CI; docs policy + manual verification).
+
+---
+
+## 0. Guiding constraints
+
+| # | Constraint | Rationale |
+|---|---|---|
+| C1 | Free at a user scale of 1 | No metered services in the default path |
+| C2 | No `.env` authoring by the user | Setup is 1–2 clicks + a device code |
+| C3 | Server is disposable | All durable state lives in GitHub |
+| C4 | Addon stays usable on a normal desktop | Deployment concerns must not leak into the addon |
+
+C4 is the one to defend hardest. Most GitPDM users will never run it in a container. Every requirement below must be a no-op or an improvement for a laptop user.
+
+---
+
+## 1. Storage & compression policy
+
+### R1.1 — Decouple compression from LFS *(priority: high)*
+
+Setting FreeCAD's compression level to 0 and enabling Git LFS are **mutually defeating**. This must be encoded in the product, not just the docs.
+
+- LFS stores each version as a whole, opaque object. There is **no delta compression, ever**.
+- Uncompressed `.FCStd` files are materially larger (~3–5x).
+- Therefore compression=0 + LFS = *multiplied* LFS storage and bandwidth consumption against a 1 GiB free tier.
+
+The benefit of compression=0 accrues **only to plain git**, where it enables xdelta to work at all:
+
+> Deflate cascades. A single dimension change shifts the entire compressed stream, so every subsequent byte differs. Git sees two dissimilar blobs, gives up on delta, and stores a full copy per commit. Stored (uncompressed) zip entries expose the raw `Document.xml` and BREP data, letting xdelta match unchanged regions and letting git's own zlib pack compression do the work once instead of twice.
+
+**Requirement:** GitPDM MUST treat storage mode as a single choice with coupled settings, and MUST NOT allow the incoherent combination.
+
+| Mode | Compression | LFS | Locking | Cost |
+|---|---|---|---|---|
+| `delta` **(default)** | 0 | off | none | Free, unmetered |
+| `lfs` (opt-in) | 3 (FreeCAD default) | on | available | Metered past 1 GiB |
+
+**Acceptance:**
+- Enabling LFS in the UI warns that compression will be restored to default, and explains why.
+- Selecting `delta` mode with LFS already active surfaces a blocking explanation, not a silent flip.
+- Neither mode is reachable by accident.
+
+### R1.2 — Compression must be repo-scoped, not user-global *(priority: high)*
+
+`CompressionLevel` lives in FreeCAD's global parameter store (`BaseApp/Preferences/Document/…`). Setting it from the addon changes the preference for **every document that user owns**, including non-GitPDM projects. A user with one GitPDM repo and ten unrelated FreeCAD projects would silently get bloated files across all of them.
+
+**v2 note — this is shipped behavior, not a hypothetical:** v0.4.0's `core/settings.py:ensure_git_friendly_fcstd_compression()` (called from `ui/repo_validator.py` when a repo is opened or created) silently sets the global preference to 0 and does not record the prior value, so there is nothing to restore. This requirement is therefore partly a regression fix and its priority stands.
+
+**Requirement:**
+- Store the intended mode in `.freecad-pdm/config.json` (repo-scoped, committed, travels with the project).
+- Apply the global preference only while a GitPDM repo is the active context; restore the prior value on deactivation.
+- If scoped application proves infeasible in FreeCAD's API, then the global change MUST be explicit, consented-to on first use, and logged — never silent.
+
+**Note:** existing files do not shrink until re-saved. The first save after a mode switch rewrites the whole file — expect one large commit, then normal behaviour. Document this.
+
+### R1.3 — Manage `.gitattributes` *(priority: high)*
+
+**Requirement:** on `Create Repo` in `delta` mode, write:
+
+```gitattributes
+*.FCStd binary
+```
+
+- `binary` expands to `-diff -merge -text`. This is correct and does **not** disable delta compression.
+- **Never** emit `-delta` for `*.FCStd`.
+- **Never** add `*.FCStd` to an LFS filter in `delta` mode.
+
+Either of the last two silently discards the entire benefit of R1.1, with no visible symptom until the repo is large. A test should assert their absence.
+
+### R1.4 — Honest limits *(priority: medium)*
+
+Delta gains are real but uneven. OCCT BREP geometry is still binary, and topological naming means a small parametric edit can renumber IDs and rewrite large regions. Sketches and `Document.xml` delta well; BREP less so. Docs should not promise text-like ratios.
+
+---
+
+## 2. Headless / container operation
+
+### R2.1 — Credential storage without a keyring *(priority: BLOCKER)*
+
+This is the single hard blocker for the remote deployment.
+
+Current README: Linux tokens use the Secret Service API (GNOME Keyring / KWallet); the stated fallback for headless systems is "use SSH for Git operations."
+
+Neither works here:
+- A container running Xvfb + a streaming server has **no Secret Service daemon**. Running `gnome-keyring-daemon` inside a container is fragile and itself needs an unlock secret — recreating the problem.
+- SSH fallback violates C2: the user is now generating keypairs and pasting them into GitHub. That is not two clicks.
+
+**Requirement:** add a headless credential backend, selected automatically when Secret Service is unavailable:
+
+1. **`GITPDM_TOKEN_FILE`** — read a token from a path. Satisfies Docker secrets, mounted volumes, and CI.
+2. **`GITPDM_TOKEN`** — read a token from an environment variable. **Required for platform-identity injection**: Fly, AWS, GCP and most PaaS platforms inject secrets as env vars, *not* files. Supporting only `_FILE` would exclude every platform-native secret store.
+3. **File backend** — persist to `~/.config/GitPDM/credentials.json`, mode `0600`, on a mounted volume so it survives container recreation. Gate behind explicit opt-in (`GITPDM_ALLOW_FILE_TOKENS=1`) so it can never silently downgrade a desktop user's security.
+
+**Resolution precedence:**
+
+```
+GITPDM_TOKEN_FILE  >  GITPDM_TOKEN  >  keyring  >  device flow (if provider supports)  >  PAT prompt
+```
+
+**Acceptance:** GitPDM authenticates and pushes in a container with no keyring daemon, no SSH key, and no `.env` file.
+
+### R2.1a — Model token expiry and refresh *(priority: high)*
+
+The credential layer must not assume "a token" is a single opaque, immortal string. Provider behaviour differs materially:
+
+| Provider | Access token lifetime | Refresh required |
+|---|---|---|
+| GitHub (OAuth App) | Does not expire by default | No |
+| GitHub (GitHub App, user-to-server) | ~8 hours | Yes, rotating |
+| GitLab (OAuth) | **2 hours default** (instance-configurable) | Yes |
+| PAT / SSH | Until revoked/expiry set by user | No |
+
+**Requirement:** the credential record is `{ access_token, refresh_token?, expires_at?, provider }`, not a string. Refresh is attempted transparently before an operation when `expires_at` is near. A failed refresh degrades to re-auth, not a crash mid-push.
+
+**Rationale (corrected in v2):** the first draft assumed GitPDM modeled tokens as immortal strings. It does not — `TokenResponse` already carries `refresh_token`/`expires_in`/`obtained_at_utc`, and `auth/token_refresh.py` implements expiry detection with a 5-minute buffer, transparent refresh, and graceful degradation. **The remaining gap is only the `provider` field and un-hardcoding the GitHub token URL** so the same machinery serves GitLab's 2-hour tokens. See §5 and Phase G1 of the dev plan.
+
+**Note:** GitHub OAuth App tokens not expiring is a convenience *and* a liability — a leaked token is leaked indefinitely. This is one argument for treating re-auth on cold start as acceptable rather than something to engineer around.
+
+### R2.2 — Device flow is the setup UX *(priority: high)*
+
+The existing OAuth device flow is the right primitive and needs no redesign — it is the reason this deployment is viable at all. It requires no callback URL, no open port, and no local browser. The user sees a short code rendered in the FreeCAD panel over the video stream, authorises it on their phone, and lands connected.
+
+**Requirement:** ensure the device-flow dialog is fully usable at streamed resolutions and does not depend on `xdg-open` succeeding (there is no browser in the container). The dialog must render the URL and code as **selectable text**, with the "open browser" button treated as an optional convenience that fails gracefully.
+
+### R2.3 — Concurrent session guard *(priority: medium)*
+
+A hosted deployment makes it trivial to open two browser tabs against one repo and one working tree. The README already notes that `.FCStd` files can corrupt if the working directory changes while documents are open.
+
+**Requirement:** advisory lockfile in `.git/gitpdm.lock` with PID + timestamp. Second instance warns rather than proceeds. Cheap insurance now; expensive to retrofit once people have workflows.
+
+### R2.4 — Fast bootstrap: shallow clone & panel-driven setup *(priority: high)*
+
+The deployment clones on boot with no volume; clone time is cold-start time. Additionally, the rung-2 user may deploy *before* creating a repo, so first-run setup must be completable entirely from inside the FreeCAD panel over a video stream.
+
+**Requirement:**
+- Support operating in a shallow clone (`--depth N`). Commit/push/pull must work; history views degrade gracefully ("older history not fetched — deepen?") rather than erroring.
+- First-run panel flow: *clone existing repo by URL* or *create new* (via provider API where available per §5, else instructions + paste-URL). No terminal required.
+
+### R2.5 — Continuous checkpointing *(priority: high; default ON)*
+
+**Goal:** the Onshape *guarantee* — walk away at any moment, from any device, and lose at most ~a minute of work — without the Onshape *mechanism*. Onshape persists every action because it has no files: each UI action is a transaction against a cloud feature-graph database. FreeCAD's save is a blocking, whole-file serialization of a monolithic `.FCStd` on the Qt main thread. Per-action persistence is therefore prohibitive here (UI freezes, mid-transaction corruption risk); a debounced checkpoint policy is not.
+
+**Requirement — checkpoint policy, default ON:**
+- **Triggers:** document dirty AND user idle ~30–60 s; a max-interval backstop (every 2–5 min while dirty regardless of activity); on external signal (the deployment's SIGTERM handler calls this hook on platform stop/sleep).
+- **Guard:** never fire while a command/transaction is active — check FreeCAD's active-transaction state before saving.
+- **Action:** save the document, commit to a dedicated `gitpdm/recovery` branch. The git commit + push run asynchronously (subprocess); only the save itself touches the main thread, and idle-triggering hides it.
+- **Push policy split:** auto-push of the recovery branch defaults **ON in headless/container environments** (detected via the R2.1 env backends being active), **OFF on desktop** — desktop users should not get surprise background pushes to their remote; local recovery commits still protect them against crashes.
+- **Restore:** on session start, if `gitpdm/recovery` is ahead of the working branch, offer restore (never auto-restore). The next real commit offers to prune/reset the recovery branch so mainline history stays clean.
+
+**Synergy note:** delta mode (R1.1) is what makes this affordable — frequent saves of uncompressed `.FCStd` files produce sublinear pack growth. In `lfs` mode, checkpoint frequency should back off (every checkpoint is a full stored object); surface this coupling in settings.
+
+**Non-goal:** continuous sync of unsaved in-memory state or per-action persistence. Save-triggered checkpointing is the honest maximum on a file-based document model; anything more fights FreeCAD and loses.
+
+### R2.6 — Touch-viable panel UI *(priority: low, Phase 4 timing)*
+
+On an iPad or phone, GitPDM's panel is operated by finger over a video stream. The core actions (stage, commit, push, pull, branch switch) need hit targets that survive that; Qt defaults don't.
+
+**Requirement:** a "large controls" toggle (or respect FreeCAD's global UI scaling) for the GitPDM panel; commit flow completable without right-click or hover-dependent controls. Full audit deferred until the deployment's Phase 4 touch pass produces real findings.
+
+---
+
+## 3. Release & packaging hygiene
+
+### R3.1 — Publish tagged releases *(priority: high)*
+
+The repo previously showed **no releases published**, but Tutorial 1 instructs users to "Download the latest GitPDM release." That link went nowhere. This is both a new-user papercut and a build blocker: the container image needs to pin a GitPDM version to be reproducible, and pinning to `main` makes the image non-deterministic.
+
+**Status (v2):** `v0.4.0` was tagged from pre-credential-engine `main` and pushed on 2026-07-16 (GitHub serves source archives for the tag; the layout `Init.py`, `InitGui.py`, `freecad_gitpdm/` is the repo root, so the archive matches the tutorial). Remaining work, in Phase G2: a Release page with a purpose-built archive, automated on tag, and the `v0.5.0` release carrying the credential engine — which is the version the container image should pin, since headless auth (R2.1) lands there.
+
+### R3.2 — Refresh the support matrix *(priority: medium)*
+
+README lists FreeCAD 0.20 / 0.21 / 1.0. FreeCAD 1.1 shipped March 2026 and 1.1.1 in April; the project has moved to CalVer with time-based releases, so this table will now drift faster than it used to.
+
+**Requirement (reworded in v2):** state a tested-against version and a policy (e.g. "current stable + one prior") in the README, verified manually before each release. There is deliberately **no FreeCAD version in CI** — the test suite mocks FreeCAD by design (`tests/conftest.py`), so "add a CI matrix entry for 1.1.x" as originally written had nothing to attach to. If real-FreeCAD smoke testing in CI is ever wanted (headless AppImage/conda job), that is a separate, explicitly-scoped work item — not part of this requirement.
+
+### R3.3 — Addon Manager index *(priority: low)*
+
+Manual install into `Mod/` is a real adoption tax. Submit to the FreeCAD ≥1.0 addon index.
+
+---
+
+## 4. Documentation corrections
+
+### R4.1 — Rewrite "Git LFS (Why It's Recommended for CAD)" *(priority: high)*
+
+As written, this section actively causes the harm R1.1 describes: a user follows the README, enables LFS, and the compression change inflates their storage and bandwidth rather than reducing it. Replacement draft:
+
+> **Storage modes**
+>
+> **Delta mode (default, free).** GitPDM saves `.FCStd` files uncompressed so that git can store only what actually changed between versions, rather than a fresh copy each commit. Repos stay small, and plain git on GitHub is free and unmetered. Individual files on disk are larger; this is intentional and is what makes the history small.
+>
+> **LFS mode (opt-in, for teams).** Git LFS adds file locking — the ability to reserve a file so a teammate cannot edit it simultaneously. Because `.FCStd` files cannot be merged, locking is the only real answer to concurrent edits. The cost: LFS stores every version in full, with no delta compression, and GitHub's free LFS allowance is ~1 GiB of storage and ~1 GiB/month of bandwidth. GitPDM restores normal compression in this mode to keep those numbers down.
+>
+> **Which do I want?** Working alone: delta mode. You do not have a concurrency problem, and delta mode is free. Sharing write access with others: LFS mode, and budget for a data pack.
+
+### R4.2 — Document the delta/LFS coupling in the reference section
+
+State plainly: compression=0 and LFS are opposites. Anyone reading the technical reference should not have to infer it.
+
+### R4.3 — Rename away from "GitHub-based" *(priority: medium)*
+
+README currently reads *"An Open Source **Github** Based PDM Addon For FreeCAD"*, and the repo topics list `github`. Per §5, GitHub is a convenience default, not a dependency — the transport layer is already host-agnostic today.
+
+**Requirement:** retitle to git-based (the project name is already correct), and adjust topics. Worth doing before the ecosystem anchors on the GitHub association; the name is the cheapest thing to change now and the most expensive later.
+
+---
+
+## 5. Host agnosticism (provider abstraction)
+
+**Goal:** the stack works with any git host — GitHub, GitLab, Gitea/Forgejo, Bitbucket, or a bare SSH remote. GitHub is the convenience default, not a dependency.
+
+This promotes an existing roadmap item ("Support for additional hosting providers") from long-term idea to architectural constraint, because retrofitting it is dramatically more expensive than designing for it.
+
+### The three layers
+
+| Layer | Host-specific? | Work |
+|---|---|---|
+| **Git transport** (commit/push/pull/fetch/clone) | No — already generic via the `git/` subprocess wrapper | **None. Already works today.** |
+| **Credentials** | Partially | PAT/SSH is universal; device flow is a per-provider bonus |
+| **Host API** (repo creation, PRs) | Yes | Adapter per provider |
+
+Note that **Git LFS locking is part of the LFS server specification**, not a GitHub API. GitHub, GitLab and Gitea all implement it. D1 (locking) therefore inherits host-agnosticism for free.
+
+### R5.1 — Generic provider is the base case, not the fallback *(priority: high)*
+
+**Build the generic adapter first.** Make "plain git + PAT, no host API" the base class that GitHub *extends* — not a degraded path retrofitted after the fact. If GitHub is built first, its assumptions leak into `core/`, `ui/`, and `export/`, and excavating them later costs several times more than doing it in the right order now.
+
+**Forcing test:** GitPDM MUST be fully functional against a host with **zero API support**.
+- No repo creation API → user creates the repo in a browser and pastes the URL.
+- No PR integration → feature absent, not broken.
+- Previews are just committed files → already work anywhere.
+
+If everything degrades cleanly to that, the layering is correct.
+
+**Requirement:** restructure `github/` → `providers/` with `base.py` (generic: plain git + PAT/SSH), then `github.py`, `gitlab.py`, `gitea.py` as extensions. Capabilities are declared, not assumed:
+
+```python
+class Provider:
+    supports_device_flow: bool
+    supports_repo_creation: bool
+    supports_lfs_locking: bool
+    supports_pull_requests: bool
+```
+
+UI hides what the active provider can't do. It never offers an action that will fail.
+
+### R5.2 — Device flow support matrix *(priority: medium)*
+
+Verified as of July 2026:
+
+| Host | Device flow | Notes |
+|---|---|---|
+| GitHub | ✅ | Widely supported |
+| GitLab 17.9+ | ✅ GA | Feature flag `oauth2_device_grant_flow` removed at 17.9; tokens expire in 2h (see R2.1a) |
+| Gitea / Forgejo | ❌ | Open proposal only (`go-gitea/gitea#27309`), not accepted |
+| Bitbucket / bare SSH | ❌ | PAT / key |
+
+**The structural limit:** even where device flow exists, a *self-hosted* instance requires its own OAuth app registration. There is no universal client ID for self-hosted forges. The property that makes GitHub two clicks — one pre-registered app serving infinite instances — is unavailable off-SaaS.
+
+**This is acceptable and needs no solution**, because it maps onto the existing persona split:
+
+- **Non-self-hoster (2-click):** GitHub or gitlab.com. SaaS, one pre-registered app, device flow, zero config.
+- **Self-hoster (technical):** any forge, PAT or SSH key via `.env`. Registering an OAuth app on their own Gitea would be *more* work than pasting a PAT, not less.
+
+**PAT/SSH is the universal floor.** Every git host supports one.
+
+### R5.3 — Provider config is repo-scoped *(priority: medium)*
+
+Store provider identity and remote host in `.freecad-pdm/config.json` alongside storage mode (R1.2). Config travels with the project; a user can have a GitHub repo and a Forgejo repo open in the same FreeCAD session without global state fighting them.
+
+### R5.4 — Deployment warning: do not co-locate the forge *(priority: doc)*
+
+Self-hosting Forgejo *next to* the workstation container is thematically attractive (fully vendor-free) but **destroys the property the deployment architecture rests on**.
+
+"The server is disposable because all durable state lives in the git host" holds only while the host is *somewhere else*. Co-locating reintroduces a pet with precious state requiring backups, and the ephemeral cost model dies with it.
+
+Forgejo on a *separate* box or a small VPS preserves everything. Document this explicitly — it is a trap that looks like good practice.
+
+## 5b. Ecosystem integration — HistoryWorkbench *(R5.5)*
+
+**Context:** HistoryWorkbench (`eblanshey/HistoryWorkbench`, LGPL-2.1, v0.1.0 June 2026, FreeCAD 1.1+) already ships visual 3D diff (added/removed/shared geometry in distinct colors), tree/property comparison down to constraints and expressions, multi-document assembly review, and a git-free review vocabulary — using git internally. Its roadmap gap ("push to GitHub or other git remote services") is GitPDM's core competency; GitPDM's gap (visual diff) is its core competency. Integrate, do not fork.
+
+### R5.5a — Interop spike *(priority: high; do before any adapter code)*
+
+HW manages git state with its own semantics (iterations, reviewed snapshots, its own initialize flow). Two addons writing git state to one working tree is the collision risk. **Spike:** install both on one project; determine whether HW can (a) operate read-only against a GitPDM-managed repo, (b) keep its internal store in a gitignored subdirectory, or (c) needs an upstream "external git management" mode. Outcome (c) becomes agenda item one of the upstream discussion. Record findings before writing the adapter.
+
+### R5.5b — Adapter, not dependency *(priority: high)*
+
+- Single choke point: `integrations/history_wb.py` is the **only** module allowed to know HW exists.
+- Runtime feature detection (import probe + minimum-version check); **never imported at module load**; the "Visual diff" action renders only when HW is present and version-compatible — same capability-flag pattern as R5.1.
+- GitPDM's half of the handshake is minimal: materialize any two commits of an `.FCStd` to temp files (`git show rev:path`) and invoke HW's compare entry point.
+- **License boundary:** HW stays a separate installed addon. No vendored or forked HW code in GitPDM — LGPL-2.1 obligations stay outside the codebase.
+- GitPDM remains fully functional with HW uninstalled.
+
+### R5.5c — Tested-pair CI *(priority: medium)*
+
+CI job: commit a part twice with a dimension change, invoke the adapter, assert the comparison opens. Runs on any bump of either addon's pinned version. The deployment image ships only version pairs this test has passed (`GITPDM_VERSION` + `HISTORY_WB_VERSION` build args) — breakage prevention by consuming upstream progress, not freezing it.
+
+### R5.5d — Upstream collaboration *(priority: high, non-code)*
+
+Open a discussion with the HW author proposing division of labor: HW owns comparison/review/history UX; GitPDM owns remotes, auth, PDM semantics, deployment. Note the D2 overlap — HW's roadmap already includes `.FCStd` rename detection; coordinate rather than duplicate.
+
+---
+
+## 6. Deferred / research
+
+### D1 — File locking
+
+Real check-out/check-in via `git-lfs` native locking (`lockable` in `.gitattributes`, `git lfs lock` / `unlock`). GitHub already implements the server API — it exists because game studios have the same un-mergeable-binary problem. Ships with LFS mode, not before. **Not needed at user scale 1.**
+
+### D2 — Assembly link integrity
+
+The genuine gap in every git-based approach, and probably GitPDM's most defensible long-term differentiator. Git tracks renames heuristically at *repo* level; FreeCAD needs link integrity at *document* level. Rename a part in git today and assembly links break silently. Solving this means hooking document save/rename and rewriting `App::Link` targets. Commercial PDM treats this as routine; no open-source git-based tool does it well. Research spike before committing — and coordinate with HistoryWorkbench first (R5.5d): its roadmap already includes `.FCStd` rename detection, so this may become a joint effort rather than a solo one.
+
+---
+
+## 7. Non-goals
+
+- Multi-tenancy or a session broker — out of scope for the addon entirely.
+- Deployment/container logic in the GitPDM repo. Dependency direction is **sister-repo → GitPDM, never the reverse** (see C4).
+- Merge conflict resolution UI (already on the roadmap; unaffected by this document).
+- **Solving OAuth app registration for self-hosted forges.** There is no universal client ID; PAT is the correct answer for that persona (R5.2).
+- Hosting an auth-broker/redirect service. Device flow's callback-free design is what avoids putting the project in the availability and trust path of every user's instance. Do not give this up.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ GitPDM is a FreeCAD workbench addon that brings Git version control and GitHub c
 **Goal:** Install GitPDM, create a repository, and make two commits.
 
 **Prerequisites:**
-- FreeCAD (0.20, 0.21, or 1.0)
+- FreeCAD — supported policy: **current stable + one prior** (1.1.x and 1.0.x
+  at the time of this release; originally developed on 0.20–1.0)
 - Git installed and available on PATH (`git --version` works)
 
 ### 1) Install GitPDM (manual)
@@ -314,7 +315,7 @@ Branch switching is currently limited because FreeCAD `.FCStd` files are ZIP arc
 
 | Requirement | Version | Notes |
 |-------------|---------|-------|
-| FreeCAD | 0.20, 0.21, or 1.0 | Install from https://www.freecad.org/downloads.php |
+| FreeCAD | Current stable + one prior (1.1.x / 1.0.x as of this release) | Policy — verified manually before each release. Originally developed on 0.20–1.0. Install from https://www.freecad.org/downloads.php |
 | Git | 2.20+ | Install from https://git-scm.com/ |
 | Python | 3.8+ | Bundled with FreeCAD |
 | PySide2 or PySide6 | Any | Bundled with FreeCAD |

--- a/freecad_gitpdm/auth/check.py
+++ b/freecad_gitpdm/auth/check.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+GitPDM Credential Check CLI
+Phase G1: Container smoke test for the credential resolution chain.
+
+Usage (no FreeCAD required):
+
+    python -m freecad_gitpdm.auth.check
+
+Resolves the credential chain (GITPDM_TOKEN_FILE > GITPDM_TOKEN >
+keyring) and verifies the token against the host API by fetching the
+authenticated login. Exit code 0 on success, 1 on failure.
+
+Environment:
+    GITPDM_HOST              Git host (default: github.com)
+    GITPDM_TOKEN_FILE        Path to a file containing a token
+    GITPDM_TOKEN             Token value
+    GITPDM_ALLOW_FILE_TOKENS Enable the file persistence backend
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+
+USER_AGENT = "GitPDM/1.0"
+
+
+def _api_user_url(host: str) -> str:
+    """API endpoint returning the authenticated user for a host."""
+    if host in ("github.com", "www.github.com", "api.github.com"):
+        return "https://api.github.com/user"
+    # GitHub Enterprise convention; other providers come with G4.
+    return f"https://{host}/api/v3/user"
+
+
+def fetch_login(host: str, access_token: str, timeout_s: int = 10) -> str:
+    """
+    Fetch the authenticated login for a token.
+
+    Raises:
+        RuntimeError: with a user-facing message on any failure.
+        (Never includes the token value.)
+    """
+    request = urllib.request.Request(
+        _api_user_url(host),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {access_token}",
+            "User-Agent": USER_AGENT,
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"API request failed (HTTP {e.code})")
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Network error: {e.reason}")
+    except json.JSONDecodeError:
+        raise RuntimeError("Invalid response from host API")
+
+    login = payload.get("login")
+    if not login:
+        raise RuntimeError("Host API response has no login field")
+    return str(login)
+
+
+def main(argv=None) -> int:
+    from freecad_gitpdm.auth.credential_chain import resolve_credential
+
+    host = os.environ.get("GITPDM_HOST", "").strip() or "github.com"
+
+    resolved = resolve_credential(host=host)
+    if resolved is None:
+        print(
+            "GitPDM auth check: FAILED — no credential resolved "
+            "(GITPDM_TOKEN_FILE, GITPDM_TOKEN, and keyring all missed)"
+        )
+        return 1
+
+    try:
+        login = fetch_login(host, resolved.token.access_token)
+    except RuntimeError as e:
+        print(
+            f"GitPDM auth check: FAILED — credential from '{resolved.source}' "
+            f"did not authenticate: {e}"
+        )
+        return 1
+
+    print(
+        f"GitPDM auth check: OK — source={resolved.source} "
+        f"provider={resolved.token.provider} host={host} login={login}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/freecad_gitpdm/auth/credential_chain.py
+++ b/freecad_gitpdm/auth/credential_chain.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""
+GitPDM Credential Resolution Chain
+Phase G1: Headless-capable credential resolution (R2.1).
+
+Resolution precedence (non-interactive rungs, tried in order):
+
+    GITPDM_TOKEN_FILE  >  GITPDM_TOKEN  >  keyring
+
+Each rung either *yields* a credential, is *missing* (silent
+fall-through), or *errors* (logged warning, fall-through — never a
+crash). If every rung misses, resolution returns None and the caller
+(UI layer) proceeds to the interactive rungs: device flow, then PAT
+prompt.
+
+SECURITY: token values must never appear in log output. Log sources and
+paths, never contents.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from freecad_gitpdm.auth.oauth_device_flow import TokenResponse
+
+
+ENV_TOKEN_FILE = "GITPDM_TOKEN_FILE"
+ENV_TOKEN = "GITPDM_TOKEN"
+ENV_PROVIDER = "GITPDM_PROVIDER"
+
+SOURCE_ENV_FILE = "env-file"
+SOURCE_ENV = "env"
+SOURCE_KEYRING = "keyring"
+
+
+@dataclass
+class ResolvedCredential:
+    """A credential plus which rung of the chain produced it."""
+
+    token: TokenResponse
+    source: str  # SOURCE_ENV_FILE | SOURCE_ENV | SOURCE_KEYRING
+
+
+def headless_backends_active(environ=None) -> bool:
+    """
+    True when an environment-variable credential backend is configured.
+
+    Used both by the chain itself and by callers that change policy in
+    headless deployments (e.g., git credential bridging; later,
+    recovery-branch auto-push per R2.5).
+    """
+    env = os.environ if environ is None else environ
+    return bool(env.get(ENV_TOKEN_FILE, "").strip() or env.get(ENV_TOKEN, "").strip())
+
+
+def _pat_token(value: str, environ) -> TokenResponse:
+    """Wrap a raw PAT string in a TokenResponse. PATs carry no expiry."""
+    provider = (environ.get(ENV_PROVIDER) or "github").strip() or "github"
+    return TokenResponse(
+        access_token=value,
+        token_type="bearer",
+        scope="",
+        provider=provider,
+    )
+
+
+def resolve_env_credential(environ=None) -> Optional[ResolvedCredential]:
+    """
+    Resolve only the environment rungs (GITPDM_TOKEN_FILE, GITPDM_TOKEN).
+
+    Returns None if both are missing or unusable.
+    """
+    from freecad_gitpdm.core import log
+
+    env = os.environ if environ is None else environ
+
+    # Rung 1: GITPDM_TOKEN_FILE
+    token_file = env.get(ENV_TOKEN_FILE, "").strip()
+    if token_file:
+        try:
+            with open(token_file, "r", encoding="utf-8") as f:
+                value = f.read().strip()
+        except OSError as e:
+            log.warning(
+                f"{ENV_TOKEN_FILE} is set but unreadable "
+                f"({e.__class__.__name__}); falling through"
+            )
+            value = ""
+        if value:
+            log.debug(f"Credential resolved from {ENV_TOKEN_FILE}")
+            return ResolvedCredential(_pat_token(value, env), SOURCE_ENV_FILE)
+        elif token_file:
+            log.warning(f"{ENV_TOKEN_FILE} points to an empty file; falling through")
+
+    # Rung 2: GITPDM_TOKEN
+    token_value = env.get(ENV_TOKEN, "").strip()
+    if token_value:
+        log.debug(f"Credential resolved from {ENV_TOKEN}")
+        return ResolvedCredential(_pat_token(token_value, env), SOURCE_ENV)
+
+    return None
+
+
+def resolve_credential(
+    host: str = "github.com",
+    account: str | None = None,
+    environ=None,
+    store_factory=None,
+) -> Optional[ResolvedCredential]:
+    """
+    Resolve a credential through the full non-interactive chain.
+
+    Args:
+        host: Git host the credential is for (keyring lookup key).
+        account: Optional account name (keyring lookup key).
+        environ: Override environment mapping (tests).
+        store_factory: Callable returning a TokenStore (tests / services);
+                       defaults to the platform factory.
+
+    Returns:
+        ResolvedCredential, or None if every rung missed (caller should
+        proceed to device flow / PAT prompt).
+    """
+    from freecad_gitpdm.core import log
+
+    resolved = resolve_env_credential(environ)
+    if resolved is not None:
+        return resolved
+
+    # Rung 3: keyring (or file store when enabled and keyring absent)
+    try:
+        if store_factory is None:
+            from freecad_gitpdm.auth.token_store_factory import create_token_store
+
+            store_factory = create_token_store
+        store = store_factory()
+        token = store.load(host, account)
+    except Exception as e:
+        log.warning(
+            f"Token store unavailable ({e.__class__.__name__}); falling through"
+        )
+        return None
+
+    if token is not None and token.access_token:
+        log.debug("Credential resolved from token store")
+        return ResolvedCredential(token, SOURCE_KEYRING)
+
+    return None

--- a/freecad_gitpdm/auth/oauth_device_flow.py
+++ b/freecad_gitpdm/auth/oauth_device_flow.py
@@ -81,6 +81,10 @@ class TokenResponse:
         expires_in: int | None - Seconds until token expires
         refresh_token_expires_in: int | None - Seconds until refresh_token expires
         obtained_at_utc: str - ISO 8601 UTC timestamp when token was obtained
+        provider: str - Git host provider this token belongs to
+                        (e.g., "github", "gitlab"); defaults to "github"
+                        so tokens stored before this field existed load
+                        unchanged
     """
 
     access_token: str
@@ -90,6 +94,7 @@ class TokenResponse:
     expires_in: Optional[int] = None
     refresh_token_expires_in: Optional[int] = None
     obtained_at_utc: str = ""
+    provider: str = "github"
 
 
 def request_device_code(

--- a/freecad_gitpdm/auth/scope_validator.py
+++ b/freecad_gitpdm/auth/scope_validator.py
@@ -28,7 +28,7 @@ def parse_scopes(scope_string: str) -> Set[str]:
     Parse space-separated or comma-separated scope string into set.
 
     Args:
-        scope_string: Space-separated or comma-separated OAuth scopes 
+        scope_string: Space-separated or comma-separated OAuth scopes
                      (e.g., "repo read:user" or "repo,read:user")
 
     Returns:
@@ -38,7 +38,7 @@ def parse_scopes(scope_string: str) -> Set[str]:
         return set()
     # Handle both space-separated and comma-separated formats
     # GitHub typically uses space-separated, but some responses may use commas
-    delimiter = ',' if ',' in scope_string and ' ' not in scope_string else ' '
+    delimiter = "," if "," in scope_string and " " not in scope_string else " "
     return set(s.strip() for s in scope_string.split(delimiter) if s.strip())
 
 

--- a/freecad_gitpdm/auth/token_store_factory.py
+++ b/freecad_gitpdm/auth/token_store_factory.py
@@ -10,9 +10,34 @@ import sys
 from freecad_gitpdm.auth.token_store import TokenStore
 
 
+def _store_usable(store: TokenStore) -> bool:
+    """
+    Cheap availability probe for a platform store.
+
+    Only consulted when the file backend is explicitly enabled
+    (GITPDM_ALLOW_FILE_TOKENS=1), i.e., in headless environments where
+    the OS credential service may be absent at runtime even though the
+    store class constructs fine (e.g., Linux without a Secret Service
+    daemon).
+    """
+    if getattr(store, "_available", True) is False:
+        return False
+    try:
+        store.load("gitpdm.availability-probe.invalid", None)
+    except Exception:
+        return False
+    return True
+
+
 def create_token_store() -> TokenStore:
     """
     Create the appropriate token store for the current platform.
+
+    When GITPDM_ALLOW_FILE_TOKENS=1 is set and the platform's OS
+    credential store is unavailable, falls back to the file-based store
+    (headless/container environments, R2.1). Without that flag the file
+    backend is unreachable and behavior is unchanged from previous
+    releases.
 
     Returns:
         TokenStore: Platform-specific token store implementation
@@ -20,6 +45,32 @@ def create_token_store() -> TokenStore:
     Raises:
         OSError: If no token store is available for the current platform
     """
+    from freecad_gitpdm.auth.token_store_file import (
+        FileTokenStore,
+        file_tokens_allowed,
+    )
+
+    try:
+        store = _create_platform_store()
+    except OSError:
+        if file_tokens_allowed():
+            return FileTokenStore()
+        raise
+
+    if file_tokens_allowed() and not _store_usable(store):
+        from freecad_gitpdm.core import log
+
+        log.warning(
+            "OS credential store unavailable; using file token store "
+            "(GITPDM_ALLOW_FILE_TOKENS=1)"
+        )
+        return FileTokenStore()
+
+    return store
+
+
+def _create_platform_store() -> TokenStore:
+    """Create the OS-keyring store for the current platform."""
     if sys.platform == "win32":
         # Windows: Use Windows Credential Manager
         from freecad_gitpdm.auth.token_store_wincred import WindowsCredentialStore

--- a/freecad_gitpdm/auth/token_store_file.py
+++ b/freecad_gitpdm/auth/token_store_file.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""
+GitPDM File-Based Token Store (headless environments)
+Phase G1: Credential persistence without an OS keyring.
+
+Stores tokens as JSON in ~/.config/GitPDM/credentials.json with mode 0600.
+Intended for containers and other headless environments where no OS
+credential service exists (see GITPDM_REQUIREMENTS.md R2.1).
+
+SECURITY: This backend is gated behind the GITPDM_ALLOW_FILE_TOKENS=1
+environment variable. Without the flag, constructing the store raises —
+it must be unreachable so it can never silently downgrade a desktop
+user's security. This invariant is asserted by tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from freecad_gitpdm.auth.token_store import TokenStore
+from freecad_gitpdm.auth.oauth_device_flow import TokenResponse
+from freecad_gitpdm.auth.keys import credential_target_name
+
+
+ALLOW_FILE_TOKENS_ENV = "GITPDM_ALLOW_FILE_TOKENS"
+
+
+def file_tokens_allowed(environ=None) -> bool:
+    """Return True if the file token backend is explicitly enabled."""
+    env = os.environ if environ is None else environ
+    return env.get(ALLOW_FILE_TOKENS_ENV, "") == "1"
+
+
+def default_credentials_path() -> Path:
+    """Default credentials file location (all platforms)."""
+    return Path.home() / ".config" / "GitPDM" / "credentials.json"
+
+
+class FileTokenStore(TokenStore):
+    """
+    Token storage in a JSON file, for keyring-less environments.
+
+    The file maps credential target names (see auth/keys.py) to the same
+    per-field JSON dict the OS-keyring stores use, so tokens are portable
+    between backends.
+    """
+
+    def __init__(self, path: str | os.PathLike | None = None, environ=None):
+        """
+        Args:
+            path: Override the credentials file location (mainly for tests).
+            environ: Override environment mapping (mainly for tests).
+
+        Raises:
+            OSError: If GITPDM_ALLOW_FILE_TOKENS=1 is not set.
+        """
+        if not file_tokens_allowed(environ):
+            raise OSError(
+                "File token storage is disabled. Set "
+                f"{ALLOW_FILE_TOKENS_ENV}=1 to enable it (headless "
+                "environments only)."
+            )
+        self._path = Path(path) if path is not None else default_credentials_path()
+
+    def _read_all(self) -> dict:
+        try:
+            with open(self._path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Credentials file is corrupted: {e}")
+        if not isinstance(data, dict):
+            raise ValueError("Credentials file has unexpected structure")
+        return data
+
+    def _write_all(self, data: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self._path.parent, 0o700)
+        except OSError:
+            pass  # best effort on platforms without POSIX modes
+        tmp_path = self._path.with_suffix(".json.tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp_path, self._path)
+        try:
+            os.chmod(self._path, 0o600)
+        except OSError:
+            pass
+
+    def save(self, host: str, account: str | None, token: TokenResponse) -> None:
+        from freecad_gitpdm.core import log
+
+        target_name = credential_target_name(host, account)
+        data = self._read_all()
+        data[target_name] = {
+            "access_token": token.access_token,
+            "token_type": token.token_type,
+            "scope": token.scope,
+            "refresh_token": token.refresh_token,
+            "expires_in": token.expires_in,
+            "refresh_token_expires_in": token.refresh_token_expires_in,
+            "obtained_at_utc": token.obtained_at_utc,
+            "provider": token.provider,
+        }
+        self._write_all(data)
+        log.debug(f"Token stored for {target_name} in credentials file")
+
+    def load(self, host: str, account: str | None) -> TokenResponse | None:
+        from freecad_gitpdm.core import log
+
+        data = self._read_all()
+
+        # Primary lookup, then host-only fallback (same migration
+        # behaviour as the OS-keyring stores).
+        targets = [credential_target_name(host, account)]
+        if account:
+            fallback = credential_target_name(host, None)
+            if fallback not in targets:
+                targets.append(fallback)
+
+        for target_name in targets:
+            token_data = data.get(target_name)
+            if token_data is None:
+                continue
+            log.debug(f"Token loaded for {target_name} from credentials file")
+            return TokenResponse(
+                access_token=token_data.get("access_token", ""),
+                token_type=token_data.get("token_type", "bearer"),
+                scope=token_data.get("scope", ""),
+                refresh_token=token_data.get("refresh_token"),
+                expires_in=token_data.get("expires_in"),
+                refresh_token_expires_in=token_data.get("refresh_token_expires_in"),
+                obtained_at_utc=token_data.get("obtained_at_utc", ""),
+                provider=token_data.get("provider", "github"),
+            )
+        return None
+
+    def delete(self, host: str, account: str | None) -> None:
+        from freecad_gitpdm.core import log
+
+        data = self._read_all()
+        targets = [credential_target_name(host, account)]
+        if account:
+            targets.append(credential_target_name(host, None))
+
+        removed = False
+        for target_name in targets:
+            if target_name in data:
+                del data[target_name]
+                removed = True
+                log.debug(f"Token deleted for {target_name} from credentials file")
+        if removed:
+            self._write_all(data)

--- a/freecad_gitpdm/auth/token_store_linux.py
+++ b/freecad_gitpdm/auth/token_store_linux.py
@@ -86,6 +86,7 @@ class LinuxSecretServiceStore(TokenStore):
             "expires_in": token.expires_in,
             "refresh_token_expires_in": token.refresh_token_expires_in,
             "obtained_at_utc": token.obtained_at_utc,
+            "provider": token.provider,
         }
         token_json = json.dumps(token_data)
 
@@ -183,6 +184,7 @@ class LinuxSecretServiceStore(TokenStore):
                 expires_in=token_data.get("expires_in"),
                 refresh_token_expires_in=token_data.get("refresh_token_expires_in"),
                 obtained_at_utc=token_data.get("obtained_at_utc", ""),
+                provider=token_data.get("provider", "github"),
             )
 
         except Exception as e:

--- a/freecad_gitpdm/auth/token_store_macos.py
+++ b/freecad_gitpdm/auth/token_store_macos.py
@@ -86,6 +86,7 @@ class MacOSKeychainStore(TokenStore):
             "expires_in": token.expires_in,
             "refresh_token_expires_in": token.refresh_token_expires_in,
             "obtained_at_utc": token.obtained_at_utc,
+            "provider": token.provider,
         }
         token_json = json.dumps(token_data)
 
@@ -161,6 +162,7 @@ class MacOSKeychainStore(TokenStore):
                 expires_in=token_data.get("expires_in"),
                 refresh_token_expires_in=token_data.get("refresh_token_expires_in"),
                 obtained_at_utc=token_data.get("obtained_at_utc", ""),
+                provider=token_data.get("provider", "github"),
             )
 
         except json.JSONDecodeError as e:

--- a/freecad_gitpdm/auth/token_store_wincred.py
+++ b/freecad_gitpdm/auth/token_store_wincred.py
@@ -139,6 +139,7 @@ class WindowsCredentialStore(TokenStore):
             "expires_in": token.expires_in,
             "refresh_token_expires_in": token.refresh_token_expires_in,
             "obtained_at_utc": token.obtained_at_utc,
+            "provider": token.provider,
         }
         token_json = json.dumps(token_data)
         token_bytes = token_json.encode("utf-8")
@@ -243,6 +244,7 @@ class WindowsCredentialStore(TokenStore):
                     expires_in=token_data.get("expires_in"),
                     refresh_token_expires_in=token_data.get("refresh_token_expires_in"),
                     obtained_at_utc=token_data.get("obtained_at_utc", ""),
+                    provider=token_data.get("provider", "github"),
                 )
             finally:
                 # Free credential

--- a/freecad_gitpdm/core/services.py
+++ b/freecad_gitpdm/core/services.py
@@ -71,7 +71,22 @@ class ServiceContainer:
         return jobs.get_job_runner()
 
     def github_api_client(self):
-        """Create a GitHubApiClient from stored token, or return None."""
+        """Create a GitHubApiClient from the credential chain, or None.
+
+        Environment-provided credentials (GITPDM_TOKEN_FILE / GITPDM_TOKEN,
+        Phase G1) take precedence and require no configured host or stored
+        token. With no env backends active, behavior is unchanged: a host
+        setting plus a stored token are required.
+        """
+
+        from freecad_gitpdm.auth.credential_chain import resolve_env_credential
+        from freecad_gitpdm.github.api_client import GitHubApiClient
+
+        ua = "GitPDM/1.0"
+
+        env_cred = resolve_env_credential()
+        if env_cred is not None:
+            return GitHubApiClient("api.github.com", env_cred.token.access_token, ua)
 
         host = (self.settings.load_github_host() or "").strip()
         if not host:
@@ -84,9 +99,6 @@ class ServiceContainer:
         if not token_resp:
             return None
 
-        from freecad_gitpdm.github.api_client import GitHubApiClient
-
-        ua = "GitPDM/1.0"
         return GitHubApiClient("api.github.com", token_resp.access_token, ua)
 
 

--- a/freecad_gitpdm/git/client.py
+++ b/freecad_gitpdm/git/client.py
@@ -512,7 +512,8 @@ class GitClient:
                 [git_cmd, "-C", repo_root, "branch", "--format=%(refname:short)"],
                 capture_output=True,
                 text=True,
-                timeout=15 ** _get_subprocess_kwargs(),
+                timeout=15,
+                **_get_subprocess_kwargs(),
             )
             if result.returncode == 0:
                 branches = [
@@ -560,7 +561,8 @@ class GitClient:
                 [git_cmd, "-C", repo_root, "branch", "-r", "--format=%(refname:short)"],
                 capture_output=True,
                 text=True,
-                timeout=15 ** _get_subprocess_kwargs(),
+                timeout=15,
+                **_get_subprocess_kwargs(),
             )
             if result.returncode == 0:
                 branches = [
@@ -1531,8 +1533,8 @@ class GitClient:
                 command,
                 capture_output=True,
                 text=True,
-                timeout=120  # 2 minutes for pull
-                ** _get_subprocess_kwargs(),
+                timeout=120,  # 2 minutes for pull
+                **_get_subprocess_kwargs(),
             )
 
             result["stdout"] = proc_result.stdout.strip()

--- a/freecad_gitpdm/git/client.py
+++ b/freecad_gitpdm/git/client.py
@@ -32,6 +32,39 @@ def _get_subprocess_kwargs():
     return kwargs
 
 
+def _headless_credential_args():
+    """
+    Extra `git -c` arguments bridging environment-provided tokens
+    (GITPDM_TOKEN / GITPDM_TOKEN_FILE) into git's credential lookup for
+    network operations (Phase G1 / R2.1: containers have no keyring and
+    no interactive credential helper).
+
+    Returns [] on desktop (no env credential backends active), leaving
+    the user's normal credential helper (e.g., GitHub Desktop) untouched.
+    The helper script references the env vars by name only — no token
+    value ever appears on a command line or in a process listing.
+    """
+    try:
+        from freecad_gitpdm.auth.credential_chain import headless_backends_active
+
+        if not headless_backends_active():
+            return []
+    except Exception:
+        return []
+
+    helper = (
+        '!f() { if [ "$1" = "get" ]; then '
+        'echo "username=x-access-token"; '
+        'if [ -n "$GITPDM_TOKEN_FILE" ]; then '
+        'echo "password=$(cat "$GITPDM_TOKEN_FILE")"; '
+        'else echo "password=$GITPDM_TOKEN"; fi; '
+        "fi; }; f"
+    )
+    # The empty helper first clears any system-configured helpers so the
+    # env-provided token is authoritative in headless mode.
+    return ["-c", "credential.helper=", "-c", f"credential.helper={helper}"]
+
+
 # Status kinds for porcelain parsing
 STATUS_MODIFIED = "MODIFIED"
 STATUS_ADDED = "ADDED"
@@ -411,7 +444,7 @@ class GitClient:
                     )
 
             result = subprocess.run(
-                [git_cmd, "clone", clone_url, dest_abs],
+                [git_cmd, *_headless_credential_args(), "clone", clone_url, dest_abs],
                 capture_output=True,
                 text=True,
                 timeout=300,
@@ -1076,7 +1109,14 @@ class GitClient:
         git_cmd = self._get_git_command()
         try:
             proc_result = subprocess.run(
-                [git_cmd, "-C", repo_root, "fetch", remote],
+                [
+                    git_cmd,
+                    *_headless_credential_args(),
+                    "-C",
+                    repo_root,
+                    "fetch",
+                    remote,
+                ],
                 capture_output=True,
                 text=True,
                 timeout=120,
@@ -1451,10 +1491,11 @@ class GitClient:
 
         git_cmd = self._get_git_command()
 
+        cred_args = _headless_credential_args()
         if self.has_upstream(repo_root):
-            args = [git_cmd, "-C", repo_root, "push"]
+            args = [git_cmd, *cred_args, "-C", repo_root, "push"]
         else:
-            args = [git_cmd, "-C", repo_root, "push", "-u", remote, "HEAD"]
+            args = [git_cmd, *cred_args, "-C", repo_root, "push", "-u", remote, "HEAD"]
 
         result = self._run_command(args, timeout=180)
 
@@ -1518,6 +1559,7 @@ class GitClient:
                 # Use: git pull --ff-only <remote> <branch>
                 command = [
                     git_cmd,
+                    *_headless_credential_args(),
                     "-C",
                     repo_root,
                     "pull",
@@ -1527,7 +1569,14 @@ class GitClient:
                 ]
             else:
                 # Use: git pull --ff-only (default upstream)
-                command = [git_cmd, "-C", repo_root, "pull", "--ff-only"]
+                command = [
+                    git_cmd,
+                    *_headless_credential_args(),
+                    "-C",
+                    repo_root,
+                    "pull",
+                    "--ff-only",
+                ]
 
             proc_result = subprocess.run(
                 command,

--- a/freecad_gitpdm/github/identity.py
+++ b/freecad_gitpdm/github/identity.py
@@ -40,9 +40,9 @@ def fetch_viewer_identity(client: GitHubApiClient) -> IdentityResult:
 
     try:
         # Load current token to check expiry
-        from freecad_gitpdm.auth.token_store_factory import get_token_store
+        from freecad_gitpdm.auth.token_store_factory import create_token_store
 
-        store = get_token_store()
+        store = create_token_store()
         host = settings.load_github_host()
         account = settings.load_github_login()
         current_token = store.load(host, account)

--- a/tests/test_auth_check.py
+++ b/tests/test_auth_check.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for auth.check — Phase G1 CLI credential smoke test.
+
+Also asserts the refresh path works end-to-end with a fake expiring
+token (G1 acceptance criterion).
+"""
+
+import io
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from freecad_gitpdm.auth import check
+from freecad_gitpdm.auth import token_refresh
+from freecad_gitpdm.auth.oauth_device_flow import TokenResponse
+
+
+def _fake_urlopen_json(payload):
+    """Build a urlopen replacement returning the given JSON payload."""
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode("utf-8")
+    opener = MagicMock()
+    opener.return_value.__enter__.return_value = response
+    return opener
+
+
+class TestCheckCli:
+    def test_ok_with_env_token(self, monkeypatch, capsys):
+        monkeypatch.setenv("GITPDM_TOKEN", "ghp_check_token_xyz")
+        monkeypatch.delenv("GITPDM_TOKEN_FILE", raising=False)
+        monkeypatch.delenv("GITPDM_HOST", raising=False)
+
+        with patch.object(
+            check.urllib.request,
+            "urlopen",
+            _fake_urlopen_json({"login": "octocat"}),
+        ):
+            rc = check.main()
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "OK" in out
+        assert "login=octocat" in out
+        assert "source=env" in out
+        # SECURITY: token value never printed
+        assert "ghp_check_token_xyz" not in out
+
+    def test_fails_with_no_credential(self, monkeypatch, capsys):
+        monkeypatch.delenv("GITPDM_TOKEN", raising=False)
+        monkeypatch.delenv("GITPDM_TOKEN_FILE", raising=False)
+
+        # Force the chain to miss so the test never touches the real
+        # OS keyring on the machine running the suite.
+        from freecad_gitpdm.auth import credential_chain
+
+        monkeypatch.setattr(
+            credential_chain,
+            "resolve_credential",
+            lambda **kwargs: None,
+        )
+
+        rc = check.main()
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "FAILED" in out
+
+    def test_fails_on_http_error(self, monkeypatch, capsys):
+        monkeypatch.setenv("GITPDM_TOKEN", "ghp_bad_token")
+
+        import urllib.error
+
+        def raise_http(*args, **kwargs):
+            raise urllib.error.HTTPError(
+                "https://api.github.com/user", 401, "Unauthorized", {}, io.BytesIO()
+            )
+
+        with patch.object(check.urllib.request, "urlopen", raise_http):
+            rc = check.main()
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "FAILED" in out
+        assert "401" in out
+        assert "ghp_bad_token" not in out
+
+    def test_enterprise_host_url(self):
+        assert (
+            check._api_user_url("github.example.com")
+            == "https://github.example.com/api/v3/user"
+        )
+        assert check._api_user_url("github.com") == "https://api.github.com/user"
+
+
+class TestRefreshPathWithFakeExpiringToken:
+    """G1 acceptance: refresh path exercised with a fake expiring token."""
+
+    def _expiring_token(self):
+        obtained = datetime.now(timezone.utc) - timedelta(hours=8)
+        return TokenResponse(
+            access_token="ghp_expired_token",
+            token_type="bearer",
+            scope="repo",
+            refresh_token="ghr_refresh_token",
+            expires_in=28800,  # 8 hours, i.e., expired just now
+            obtained_at_utc=obtained.isoformat(),
+        )
+
+    def test_expiring_token_is_detected(self):
+        assert token_refresh.is_token_expired(self._expiring_token()) is True
+
+    def test_env_pat_never_expires(self):
+        pat = TokenResponse(access_token="ghp_pat", token_type="bearer", scope="")
+        assert token_refresh.is_token_expired(pat) is False
+
+    def test_ensure_fresh_token_refreshes(self):
+        refreshed_payload = {
+            "access_token": "ghp_new_token",
+            "token_type": "bearer",
+            "scope": "repo",
+            "refresh_token": "ghr_new_refresh",
+            "expires_in": 28800,
+        }
+        with patch.object(
+            token_refresh.urllib.request,
+            "urlopen",
+            _fake_urlopen_json(refreshed_payload),
+        ):
+            ok, new_token, msg = token_refresh.ensure_fresh_token(
+                self._expiring_token(), client_id="client123"
+            )
+
+        assert ok is True
+        assert new_token is not None
+        assert new_token.access_token == "ghp_new_token"
+
+    def test_failed_refresh_degrades_to_reauth_message(self):
+        import urllib.error
+
+        def raise_url_error(*args, **kwargs):
+            raise urllib.error.URLError("network down")
+
+        with patch.object(token_refresh.urllib.request, "urlopen", raise_url_error):
+            ok, token, msg = token_refresh.ensure_fresh_token(
+                self._expiring_token(), client_id="client123"
+            )
+
+        assert ok is False
+        assert "sign in again" in msg.lower()

--- a/tests/test_credential_chain.py
+++ b/tests/test_credential_chain.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for auth.credential_chain — Phase G1 credential resolution.
+
+Covers: rung precedence, yield/miss/error semantics per rung, the
+no-token-values-in-logs invariant, and headless backend detection.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from freecad_gitpdm.auth import credential_chain
+from freecad_gitpdm.auth.credential_chain import (
+    resolve_credential,
+    resolve_env_credential,
+    headless_backends_active,
+    SOURCE_ENV_FILE,
+    SOURCE_ENV,
+    SOURCE_KEYRING,
+)
+from freecad_gitpdm.auth.oauth_device_flow import TokenResponse
+
+
+SECRET_FILE_TOKEN = "ghp_file_secret_token_AAA111"
+SECRET_ENV_TOKEN = "ghp_env_secret_token_BBB222"
+SECRET_KEYRING_TOKEN = "ghp_keyring_secret_token_CCC333"
+
+
+@pytest.fixture
+def captured_logs(monkeypatch):
+    """Capture all core.log output produced via the chain module."""
+    messages = []
+    from freecad_gitpdm.core import log
+
+    for name in ("debug", "info", "warning", "error"):
+        monkeypatch.setattr(log, name, lambda msg, _n=name: messages.append(str(msg)))
+    return messages
+
+
+def _keyring_store_with(token):
+    store = MagicMock()
+    store.load.return_value = token
+    return store
+
+
+def _keyring_token():
+    return TokenResponse(
+        access_token=SECRET_KEYRING_TOKEN,
+        token_type="bearer",
+        scope="repo",
+    )
+
+
+class TestPrecedence:
+    def test_token_file_wins_over_env_and_keyring(self, tmp_path, captured_logs):
+        token_file = tmp_path / "token.txt"
+        token_file.write_text(SECRET_FILE_TOKEN + "\n", encoding="utf-8")
+        environ = {
+            "GITPDM_TOKEN_FILE": str(token_file),
+            "GITPDM_TOKEN": SECRET_ENV_TOKEN,
+        }
+        store = _keyring_store_with(_keyring_token())
+
+        resolved = resolve_credential(environ=environ, store_factory=lambda: store)
+
+        assert resolved is not None
+        assert resolved.source == SOURCE_ENV_FILE
+        assert resolved.token.access_token == SECRET_FILE_TOKEN
+        store.load.assert_not_called()
+
+    def test_env_token_wins_over_keyring(self, captured_logs):
+        environ = {"GITPDM_TOKEN": SECRET_ENV_TOKEN}
+        store = _keyring_store_with(_keyring_token())
+
+        resolved = resolve_credential(environ=environ, store_factory=lambda: store)
+
+        assert resolved is not None
+        assert resolved.source == SOURCE_ENV
+        assert resolved.token.access_token == SECRET_ENV_TOKEN
+        store.load.assert_not_called()
+
+    def test_keyring_used_when_no_env(self, captured_logs):
+        store = _keyring_store_with(_keyring_token())
+
+        resolved = resolve_credential(
+            host="github.com",
+            account="octocat",
+            environ={},
+            store_factory=lambda: store,
+        )
+
+        assert resolved is not None
+        assert resolved.source == SOURCE_KEYRING
+        assert resolved.token.access_token == SECRET_KEYRING_TOKEN
+        store.load.assert_called_once_with("github.com", "octocat")
+
+    def test_all_rungs_miss_returns_none(self, captured_logs):
+        store = _keyring_store_with(None)
+        resolved = resolve_credential(environ={}, store_factory=lambda: store)
+        assert resolved is None
+
+
+class TestRungErrorSemantics:
+    def test_unreadable_token_file_falls_through_to_env(self, tmp_path, captured_logs):
+        environ = {
+            "GITPDM_TOKEN_FILE": str(tmp_path / "does-not-exist.txt"),
+            "GITPDM_TOKEN": SECRET_ENV_TOKEN,
+        }
+
+        resolved = resolve_credential(environ=environ, store_factory=MagicMock)
+
+        assert resolved is not None
+        assert resolved.source == SOURCE_ENV
+        assert any("GITPDM_TOKEN_FILE" in m for m in captured_logs)
+
+    def test_empty_token_file_falls_through(self, tmp_path, captured_logs):
+        token_file = tmp_path / "empty.txt"
+        token_file.write_text("", encoding="utf-8")
+        environ = {
+            "GITPDM_TOKEN_FILE": str(token_file),
+            "GITPDM_TOKEN": SECRET_ENV_TOKEN,
+        }
+
+        resolved = resolve_credential(environ=environ, store_factory=MagicMock)
+
+        assert resolved is not None
+        assert resolved.source == SOURCE_ENV
+
+    def test_keyring_error_falls_through_to_none(self, captured_logs):
+        def broken_factory():
+            raise OSError("no secret service daemon")
+
+        resolved = resolve_credential(environ={}, store_factory=broken_factory)
+
+        assert resolved is None
+        assert any("falling through" in m for m in captured_logs)
+
+    def test_keyring_load_error_falls_through_to_none(self, captured_logs):
+        store = MagicMock()
+        store.load.side_effect = OSError("dbus not available")
+
+        resolved = resolve_credential(environ={}, store_factory=lambda: store)
+
+        assert resolved is None
+
+
+class TestNoTokensInLogs:
+    """SECURITY invariant: no rung may log a token value."""
+
+    def test_no_token_values_logged_on_any_path(self, tmp_path, captured_logs):
+        token_file = tmp_path / "token.txt"
+        token_file.write_text(SECRET_FILE_TOKEN, encoding="utf-8")
+
+        # Exercise every yielding rung
+        resolve_credential(
+            environ={"GITPDM_TOKEN_FILE": str(token_file)},
+            store_factory=MagicMock,
+        )
+        resolve_credential(
+            environ={"GITPDM_TOKEN": SECRET_ENV_TOKEN}, store_factory=MagicMock
+        )
+        resolve_credential(
+            environ={},
+            store_factory=lambda: _keyring_store_with(_keyring_token()),
+        )
+        # And the error paths
+        resolve_credential(
+            environ={
+                "GITPDM_TOKEN_FILE": str(tmp_path / "missing.txt"),
+                "GITPDM_TOKEN": SECRET_ENV_TOKEN,
+            },
+            store_factory=MagicMock,
+        )
+
+        joined = "\n".join(captured_logs)
+        for secret in (SECRET_FILE_TOKEN, SECRET_ENV_TOKEN, SECRET_KEYRING_TOKEN):
+            assert secret not in joined
+
+
+class TestHeadlessDetection:
+    def test_inactive_with_empty_environ(self):
+        assert headless_backends_active(environ={}) is False
+
+    def test_active_with_token(self):
+        assert headless_backends_active(environ={"GITPDM_TOKEN": "x"}) is True
+
+    def test_active_with_token_file(self):
+        assert headless_backends_active(environ={"GITPDM_TOKEN_FILE": "/x"}) is True
+
+    def test_whitespace_only_is_inactive(self):
+        assert headless_backends_active(environ={"GITPDM_TOKEN": "  "}) is False
+
+
+class TestEnvCredentialProvider:
+    def test_provider_defaults_to_github(self):
+        resolved = resolve_env_credential(environ={"GITPDM_TOKEN": "tok"})
+        assert resolved is not None
+        assert resolved.token.provider == "github"
+
+    def test_provider_from_env(self):
+        resolved = resolve_env_credential(
+            environ={"GITPDM_TOKEN": "tok", "GITPDM_PROVIDER": "gitlab"}
+        )
+        assert resolved is not None
+        assert resolved.token.provider == "gitlab"
+
+    def test_env_token_has_no_expiry(self):
+        resolved = resolve_env_credential(environ={"GITPDM_TOKEN": "tok"})
+        assert resolved is not None
+        assert resolved.token.refresh_token is None
+        assert resolved.token.expires_in is None
+
+    def test_module_reference(self):
+        # Guard against accidental removal of the public names other
+        # modules import (git client, services).
+        assert callable(credential_chain.headless_backends_active)
+        assert callable(credential_chain.resolve_env_credential)

--- a/tests/test_git_client.py
+++ b/tests/test_git_client.py
@@ -213,3 +213,33 @@ class TestCmdResult:
         )
         assert result.ok is False
         assert result.error_code == "GIT_ERROR"
+
+
+class TestSubprocessKwargsRegression:
+    """Regression tests for the broken `timeout=N ** _get_subprocess_kwargs()`
+    splats that made these methods raise TypeError on every call."""
+
+    @patch("subprocess.run")
+    def test_list_local_branches_runs(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="main\ndev\n", stderr="")
+        client = GitClient()
+        branches = client.list_local_branches(str(tmp_path))
+        assert branches == ["main", "dev"]
+
+    @patch("subprocess.run")
+    def test_list_remote_branches_runs(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="origin/main\n", stderr=""
+        )
+        client = GitClient()
+        branches = client.list_remote_branches(str(tmp_path))
+        assert branches == ["origin/main"]
+
+    @patch("subprocess.run")
+    def test_pull_ff_only_runs(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Already up to date.", stderr=""
+        )
+        client = GitClient()
+        result = client.pull_ff_only(str(tmp_path))
+        assert result["ok"] is True

--- a/tests/test_token_store_file.py
+++ b/tests/test_token_store_file.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for auth.token_store_file and the factory gating — Phase G1.
+
+The critical invariant: the file backend is UNREACHABLE unless
+GITPDM_ALLOW_FILE_TOKENS=1 is set (desktop-security invariant).
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+from freecad_gitpdm.auth import token_store_factory
+from freecad_gitpdm.auth.oauth_device_flow import TokenResponse
+from freecad_gitpdm.auth.token_store_file import (
+    FileTokenStore,
+    file_tokens_allowed,
+    ALLOW_FILE_TOKENS_ENV,
+)
+
+
+def _token(access="ghp_file_store_test_token", provider="github"):
+    return TokenResponse(
+        access_token=access,
+        token_type="bearer",
+        scope="repo read:user",
+        refresh_token="refresh_abc",
+        expires_in=28800,
+        obtained_at_utc="2026-07-16T12:00:00+00:00",
+        provider=provider,
+    )
+
+
+ALLOWED = {ALLOW_FILE_TOKENS_ENV: "1"}
+
+
+class TestGatingInvariant:
+    def test_constructor_raises_without_flag(self, tmp_path):
+        with pytest.raises(OSError):
+            FileTokenStore(path=tmp_path / "credentials.json", environ={})
+
+    def test_constructor_raises_with_wrong_flag_value(self, tmp_path):
+        with pytest.raises(OSError):
+            FileTokenStore(
+                path=tmp_path / "credentials.json",
+                environ={ALLOW_FILE_TOKENS_ENV: "true"},
+            )
+
+    def test_file_tokens_allowed_only_when_exactly_1(self):
+        assert file_tokens_allowed({}) is False
+        assert file_tokens_allowed({ALLOW_FILE_TOKENS_ENV: "0"}) is False
+        assert file_tokens_allowed({ALLOW_FILE_TOKENS_ENV: "yes"}) is False
+        assert file_tokens_allowed({ALLOW_FILE_TOKENS_ENV: "1"}) is True
+
+    def test_factory_never_returns_file_store_without_flag(self, monkeypatch):
+        """Even with the platform store broken, no flag means no file store."""
+        monkeypatch.delenv(ALLOW_FILE_TOKENS_ENV, raising=False)
+
+        def broken_platform_store():
+            raise OSError("no platform store")
+
+        monkeypatch.setattr(
+            token_store_factory, "_create_platform_store", broken_platform_store
+        )
+        with pytest.raises(OSError):
+            token_store_factory.create_token_store()
+
+    def test_factory_falls_back_to_file_store_with_flag(self, monkeypatch):
+        monkeypatch.setenv(ALLOW_FILE_TOKENS_ENV, "1")
+
+        def broken_platform_store():
+            raise OSError("no platform store")
+
+        monkeypatch.setattr(
+            token_store_factory, "_create_platform_store", broken_platform_store
+        )
+        store = token_store_factory.create_token_store()
+        assert isinstance(store, FileTokenStore)
+
+    def test_factory_prefers_working_platform_store_even_with_flag(self, monkeypatch):
+        """The flag alone must not downgrade a user with a working keyring."""
+        monkeypatch.setenv(ALLOW_FILE_TOKENS_ENV, "1")
+
+        class WorkingStore:
+            def load(self, host, account):
+                return None
+
+        working = WorkingStore()
+        monkeypatch.setattr(
+            token_store_factory, "_create_platform_store", lambda: working
+        )
+        store = token_store_factory.create_token_store()
+        assert store is working
+
+    def test_factory_falls_back_when_platform_store_unusable(self, monkeypatch):
+        monkeypatch.setenv(ALLOW_FILE_TOKENS_ENV, "1")
+
+        class DeadStore:
+            def load(self, host, account):
+                raise OSError("secret service daemon not running")
+
+        monkeypatch.setattr(
+            token_store_factory, "_create_platform_store", lambda: DeadStore()
+        )
+        store = token_store_factory.create_token_store()
+        assert isinstance(store, FileTokenStore)
+
+
+class TestRoundTrip:
+    def test_save_load_round_trip(self, tmp_path):
+        store = FileTokenStore(path=tmp_path / "credentials.json", environ=ALLOWED)
+        token = _token()
+        store.save("github.com", "octocat", token)
+
+        loaded = store.load("github.com", "octocat")
+        assert loaded is not None
+        assert loaded.access_token == token.access_token
+        assert loaded.refresh_token == token.refresh_token
+        assert loaded.expires_in == token.expires_in
+        assert loaded.obtained_at_utc == token.obtained_at_utc
+        assert loaded.provider == "github"
+
+    def test_provider_round_trip(self, tmp_path):
+        store = FileTokenStore(path=tmp_path / "credentials.json", environ=ALLOWED)
+        store.save("gitlab.com", None, _token(provider="gitlab"))
+        loaded = store.load("gitlab.com", None)
+        assert loaded is not None
+        assert loaded.provider == "gitlab"
+
+    def test_load_missing_returns_none(self, tmp_path):
+        store = FileTokenStore(path=tmp_path / "credentials.json", environ=ALLOWED)
+        assert store.load("github.com", "nobody") is None
+
+    def test_host_only_fallback(self, tmp_path):
+        """Token saved before the username was known is still found."""
+        store = FileTokenStore(path=tmp_path / "credentials.json", environ=ALLOWED)
+        store.save("github.com", None, _token())
+        loaded = store.load("github.com", "octocat")
+        assert loaded is not None
+
+    def test_delete(self, tmp_path):
+        store = FileTokenStore(path=tmp_path / "credentials.json", environ=ALLOWED)
+        store.save("github.com", "octocat", _token())
+        store.delete("github.com", "octocat")
+        assert store.load("github.com", "octocat") is None
+
+    def test_corrupt_file_raises_value_error(self, tmp_path):
+        path = tmp_path / "credentials.json"
+        path.write_text("{not json", encoding="utf-8")
+        store = FileTokenStore(path=path, environ=ALLOWED)
+        with pytest.raises(ValueError):
+            store.load("github.com", None)
+
+    def test_multiple_hosts_coexist(self, tmp_path):
+        store = FileTokenStore(path=tmp_path / "credentials.json", environ=ALLOWED)
+        store.save("github.com", None, _token(access="tok_gh"))
+        store.save("gitlab.com", None, _token(access="tok_gl", provider="gitlab"))
+        gh = store.load("github.com", None)
+        gl = store.load("gitlab.com", None)
+        assert gh is not None and gh.access_token == "tok_gh"
+        assert gl is not None and gl.access_token == "tok_gl"
+
+    def test_file_is_valid_json_on_disk(self, tmp_path):
+        path = tmp_path / "credentials.json"
+        store = FileTokenStore(path=path, environ=ALLOWED)
+        store.save("github.com", None, _token())
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "GitPDM:github.com:oauth" in data
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="POSIX file modes not applicable"
+    )
+    def test_file_mode_0600(self, tmp_path):
+        path = tmp_path / "credentials.json"
+        store = FileTokenStore(path=path, environ=ALLOWED)
+        store.save("github.com", None, _token())
+        mode = os.stat(path).st_mode & 0o777
+        assert mode == 0o600


### PR DESCRIPTION
## Summary

First batch of work from the phased development plan (GITPDM_DEV_PLAN.md):

- **Planning docs (Draft v2)**: GITPDM_DEV_PLAN.md and GITPDM_REQUIREMENTS.md,
  reviewed and corrected against the actual codebase at v0.4.0.
- **Bug fixes**: three `timeout=N ** _get_subprocess_kwargs()` splats that made
  `list_local_branches`, `list_remote_branches`, and `pull_ff_only` raise
  TypeError on every call; dead token-refresh wiring in `github/identity.py`
  (nonexistent import silently swallowed).
- **Phase G1 — headless credential engine (R2.1, R2.1a)**: credential
  resolution chain (`GITPDM_TOKEN_FILE` > `GITPDM_TOKEN` > keyring), opt-in
  file token store gated by `GITPDM_ALLOW_FILE_TOKENS=1`, `provider` field on
  the credential record, `python -m freecad_gitpdm.auth.check` container smoke
  CLI, and env-token bridging into network git operations. Desktop behavior
  unchanged when no env backends are active.
- **Docs**: status ledger + roadmap in the plan and CLAUDE.md; README support
  matrix moved to a "current stable + one prior" policy (R3.2).

## Test plan

- Full suite: 162 passed, 1 platform-skip; ruff check/format clean;
  architecture guard OK (all on CI across 3 OSes x Python 3.10-3.12).
- Manual: desktop panel flow (branch list, pull, commit/push, device-flow
  sign-in), credential chain precedence and error rungs via
  `auth.check`, file-store gating invariant.
- Outstanding (tracked in the plan's Status ledger): docker acceptance run
  of `auth.check` in a keyring-less container; lands in CI with Phase G2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
